### PR TITLE
Update trigger keywords to use brace syntax

### DIFF
--- a/rules_engine/benchmarks/parser/benches/ability_text_examples.txt
+++ b/rules_engine/benchmarks/parser/benches/ability_text_examples.txt
@@ -1,6 +1,6 @@
 Draw a card.
 {kw: Discover} a card with cost $2. {reminder: (pick one of 4 cards with different types to put into your hand.)}
-$judgment: Return this character from your void to your hand. {flavor: Born from rust and resilience.}
+{Judgment}: Return this character from your void to your hand. {flavor: Born from rust and resilience.}
 {a}: Draw 2 cards. Discard 3 cards. {flavor: Promises under a stormy sky.}
 Draw 2 cards. Discard 2 cards. $br {kw: Reclaim}. {reminder: (you may play this dream from your void, then banish it.)}
 When you discard this character, materialize it. {flavor: Beyond lies the unknown.}
@@ -9,7 +9,7 @@ Whenever you discard a card, it gains {kw: reclaim} until end of turn. {reminder
 {Materialized}: {kw: Foresee} 2. {reminder: (Look at the top 2 cards of your deck. Put any of them into your void, then put the rest back in any order.)}
 You may play this character from your void for $0 by abandoning 2 characters. {flavor: The blade's whisper stirred darkness.}
 Whenever you discard a card, gain 1 $point. {flavor: Await the dawn of chaos.}
-$judgment: Gain $1. {flavor: Where light shines in shadow, life stirs and power flows.}
+{Judgment}: Gain $1. {flavor: Where light shines in shadow, life stirs and power flows.}
 Gain $3. {flavor: Stand before the fathomless.}
 Dissolve an enemy character. You lose 4 $points.
 If you have discarded a card this turn, this character costs $1.
@@ -17,7 +17,7 @@ If you have discarded a card this turn, this character costs $1.
 {a}: Draw a card. Discard a card. {flavor: She sifts through the wreckage of memory, searching for fragments to rebuild the future.}
 Dissolve all characters. {flavor: He watched as worlds fell.}
 Whenever you discard a card, {kw: kindle} 1. {reminder: (add +1 to the spark of your rightmost character.)}
-$judgment: Draw a card. The enemy gains 2 $points. {flavor: "Take my gift; the cost is yours alone."}
+{Judgment}: Draw a card. The enemy gains 2 $points. {flavor: "Take my gift; the cost is yours alone."}
 Once per turn, you may play a character with cost $2 or less from your void. {flavor: Between stars, destiny beckons.}
 {Materialized}: Discard 2 cards. Draw 2 cards. {flavor: In the endless maze of lights, clarity is fleeting.}
 You may return a character from your void to your hand. Draw a card. {flavor: Even in the shadow of despair, they found their way back to the light.}
@@ -28,7 +28,7 @@ If you have 8 or more cards in your void, you may play this character from your 
 {Materialized}: Draw a card. Discard a card. $br {kw: Reclaim}. {reminder: (you may play this card from your void and banish it when it leaves play.)}
 This character's spark is equal to the number of cards in your void. {flavor: Born of despair and fed by memory, it grows as the past crumbles.}
 {a} Abandon a {cardtype: warrior}: {kw: Discover} a {cardtype: warrior} with cost $1 higher than the abandoned character and materialize it.
-{Materialized}, $dissolved: Draw a card. {flavor: Peace forged under falling leaves.}
+{Materialized}, {Dissolved}: Draw a card. {flavor: Peace forged under falling leaves.}
 {fa}: Another character you control gains {kw: aegis} this turn. {reminder: (it cannot be affected by the enemy)} {flavor: She stands where others would fall.}
 {fa} $2: Another character you control gains +1 spark until your next main phase for each {cardtype: warrior} you control. {flavor: Cleave the shadows apart.}
 A character you control gains +1 spark until your next main phase for each {cardtype: warrior} you control.
@@ -41,8 +41,8 @@ Dissolve an enemy character with cost less than or equal to the number of {cardt
 {kw: Discover} a {cardtype: warrior}. {reminder: (pick one of 4 random warriors with different costs to put into your hand).}
 You may play this character from your void for $2 by banishing another card from your void. {flavor:  Death is but a detour for vengeance.}
 {ma} $2, Abandon another character with spark 1 or less: Draw 2 cards. {flavor: Knowledge comes at a cost, and he always collects.}
-{Materialized}, $judgment: If you control 2 other {cardtype: warriors}, gain $1. {flavor: He speaks not of glory, but of bonds that cannot be broken.}
-{Materialized}, $judgment:  Gain $2. {flavor: Each step forward brings light.}
+{Materialized}, {Judgment}: If you control 2 other {cardtype: warriors}, gain $1. {flavor: He speaks not of glory, but of bonds that cannot be broken.}
+{Materialized}, {Judgment}:  Gain $2. {flavor: Each step forward brings light.}
 Once per turn, when you materialize a character, gain $1. {flavor: Every step she takes invites another to follow.}
 {Materialized}: Draw a {cardtype: warrior} from your deck. {flavor: The stones whispered, and she listened.}
 {a} $2, Abandon this character, discard your hand: Draw 3 cards.
@@ -67,17 +67,17 @@ Abandon a character or discard a card. Dissolve an enemy character. {flavor: Unl
 {Materialized}: Negate an enemy dream with cost $2 or less. {flavor: Before words found form, they were lost to the void.}
 {Materialized}: Gain control of an enemy character with cost $2 or less.
 {Materialized}: Dissolve an enemy character. $br You may play this character for $0 by abandoning a character. If you do, abandon this character at end of turn.
-$judgment: Gain 1 $point. {flavor: Chasing the sun's first light.}
+{Judgment}: Gain 1 $point. {flavor: Chasing the sun's first light.}
 {Materialized}: {kw: Foresee} 2. {flavor: In the shifting sands of time, they glimpsed what was to come.}
 Once per turn, when you play a '$fast' dream, draw a card.
 Whenever you play a '$fast' dream, this character gains +2 spark.
 Whenever you play a '$fast' dream, gain 1 $point.
-{Materialized}: Return a character with cost $3 or more you control to hand. $br $judgment: Draw a card.
+{Materialized}: Return a character with cost $3 or more you control to hand. $br {Judgment}: Draw a card.
 At the end of your turn, gain $2.
 Characters in your hand have '$fast'. $br Once per turn, when you play a '$fast' character, gain $1.
 Spend all your remaining energy. Draw X cards then discard X cards, where X is the energy spent this way.
 {Materialized}: Return an enemy character to hand. {flavor: With a flick of his hand, reality folded, and they vanished.}
-$judgment: Gain 2 $points. {flavor: Every flame holds a story; every story lights the path forward.}
+{Judgment}: Gain 2 $points. {flavor: Every flame holds a story; every story lights the path forward.}
 {Materialized}: An event in your void gains {kw: reclaim} until end of turn. {reminder: (you may play it from your void, then banish it.)}
 If you have drawn 2 or more cards this turn, you may play this character from your void for $1.
 Draw 3 cards. {flavor: Every page turned reveals a universe untold.}
@@ -114,13 +114,13 @@ This character's spark is equal to the number of events in your void. {flavor: E
 Characters cost you $2 less. {flavor: Through runes and rivers, they chart the unseen paths of power.}
 Whenever you materialize a character, trigger the '$judgment' ability of each character you control.
 Until end of turn, whenever you play a character, draw a card.
-$judgment: Gain $1 for each {cardtype: spirit animal} you control. {flavor: Together, their glow lights the path.}
+{Judgment}: Gain $1 for each {cardtype: spirit animal} you control. {flavor: Together, their glow lights the path.}
 {Materialized}: Return a character you control to hand. {flavor: In its glowing wake, companions find sanctuary, hidden and secure.}
 {Materialized}: Return another character you control to hand. {flavor: Home is where the journey begins again.}
 The '$judgment' ability of characters you control triggers when you materialize them.
 Whenever you materialize another {cardtype: spirit animal}, gain $1. {flavor: Lightning follows its stride.}
-$judgment: If you control 2 other {cardtype: spirit animals}, gain $2. {flavor: They glow with the essence of forgotten wonders}
-$judgment: Gain $1 for each other character you control. {flavor: A beacon of unity beneath the ancient canopy.}
+{Judgment}: If you control 2 other {cardtype: spirit animals}, gain $2. {flavor: They glow with the essence of forgotten wonders}
+{Judgment}: Gain $1 for each other character you control. {flavor: A beacon of unity beneath the ancient canopy.}
 Each {cardtype: spirit animal} you control gains +X spark, where X is the number of {cardtype: spirit animals} you control.
 When you draw all of the cards in a copy of your deck, you win the game. {flavor: The ocean whispers, 'Draw closer, and all shall be revealed.'}
 Return all but one character you control to hand. Draw a card for each character returned.
@@ -128,11 +128,11 @@ Whenever you materialize a character, this character gains +1 spark.
 Whenever you play a {cardtype: spirit animal}, draw a card. {flavor: A light in the dusk, a guide for the lost.}
 {a} $4: Each {cardtype: spirit animal} you control gains +2 spark until your next main phase. {flavor: Its presence ignites the pack's fury.}
 Whenever you materialize another {cardtype: spirit animal}, that character gains +1 spark. {flavor: Its cry awakens strength in all who hear.}
-{Materialized}, $judgment: {kw: Kindle} 1. {flavor: Bound by light, shadow, and an unbroken oath.}
+{Materialized}, {Judgment}: {kw: Kindle} 1. {flavor: Bound by light, shadow, and an unbroken oath.}
 {Materialized}: Return a character from your void to your hand. {flavor: Through the forest's glow, it finds what others cannot.}
 {Materialized}: Draw a card. {flavor: In the ethereal green glow, answers await the curious.}
-$judgment: Gain $1. {flavor: Its light pulses with the rhythm of endless currents.}
-$judgment: Gain $2. {flavor: The air hums with its boundless power}
+{Judgment}: Gain $1. {flavor: Its light pulses with the rhythm of endless currents.}
+{Judgment}: Gain $2. {flavor: The air hums with its boundless power}
 You may look at the top card of your deck. $br You may play characters from the top of your deck.
 {Materialized}: Banish the enemy's void. {flavor: Where it prowls, the past finds no refuge.}
 {Materialized}: Draw a card for each {cardtype: spirit animal} you control.
@@ -147,7 +147,7 @@ $immediate {a}: Banish another character with spark 1 or less you control, then 
 Banish a character you control, then materialize it at end of turn. $br {kw: Reclaim} $1.
 $immediate {fa} Abandon this character: Negate an enemy event.
 {kw: Discover} a character with a {Materialized} ability. {reminder: (pick one of 4 random matching cards with different costs to put into your hand)}
-$judgment: You may banish another character you control, then materialize it. {flavor: The gate opens, the story begins anew.}
+{Judgment}: You may banish another character you control, then materialize it. {flavor: The gate opens, the story begins anew.}
 Whenever a character you control is banished, this character gains +1 spark. {flavor: Every return casts ripples.}
 Whenever a character you control is banished, {kw: kindle} 1. {flavor: What fades feeds the flames.}
 Materialize two random characters with cost $3 or less from your deck. {flavor: The light draws what darkness hides.}
@@ -161,24 +161,24 @@ Banish up to two characters you control, then materialize them.
 {ma} $4: Materialize a copy of another character you control. {flavor: The circle shimmered, and where one stood, another emerged—an echo of power made flesh.}
 If you control a {cardtype: survivor}, this character costs $1. $br You may play this character from your void.
 {a} $1, Discard a card: {kw: Kindle} 2. {flavor: When the world collapses, some rise to hold its weight.}
-{Materialized}, $judgment: If you control 2 other {cardtype: survivors}, draw a card. {flavor: In the wreckage of the old world, he finds whispers of a brighter one.}
-$dissolved: {kw: Kindle} 2. $br Whenever another {cardtype: survivor} you control is dissolved, {kw: kindle} 2.
+{Materialized}, {Judgment}: If you control 2 other {cardtype: survivors}, draw a card. {flavor: In the wreckage of the old world, he finds whispers of a brighter one.}
+{Dissolved}: {kw: Kindle} 2. $br Whenever another {cardtype: survivor} you control is dissolved, {kw: kindle} 2.
 {ma} Abandon another character: Gain $1. {flavor: They followed him, believing in the hope of rebirth. They did not know that rebirth required their lives.}
-$dissolved: Draw a card. $br Whenever another {cardtype: survivor} you control is dissolved, draw a card.
+{Dissolved}: Draw a card. $br Whenever another {cardtype: survivor} you control is dissolved, draw a card.
 $immediate {ma} Abandon another character: Put the top 2 cards of your deck into your void.
 Whenever another character you control is dissolved, draw a card. {flavor: Through the haze of destruction, he gathers fragments of hope.}
 {Materialized}: Each player discards a card. {flavor: In the ruins, strength is measured in what you're willing to lose.}
 If a character you controlled dissolved this turn, you may play this character from your void for $1.
 Whenever a character you control is dissolved, gain 1 $points. {flavor: Every soul it claims becomes a thread in the tapestry of its ascension.}
-$dissolved: You may pay $1 to return this character from your void to your hand. {flavor: Every fall is a chance to rise stronger.}
-$dissolved: A {cardtype: survivor} with cost $3 or less in your void gains {kw: reclaim} until end of turn.
-$judgment: You may pay $1 to return this character from your void to your hand. {flavor: Lost once, but never forgotten}
+{Dissolved}: You may pay $1 to return this character from your void to your hand. {flavor: Every fall is a chance to rise stronger.}
+{Dissolved}: A {cardtype: survivor} with cost $3 or less in your void gains {kw: reclaim} until end of turn.
+{Judgment}: You may pay $1 to return this character from your void to your hand. {flavor: Lost once, but never forgotten}
 You may only play this character from your void.
 If this character is in your void, {cardtype: survivors} you control have +1 spark. {flavor: His spark ignites in the hearts of those who remember him.}
 {ma} Abandon another character: {kw: Kindle} 1. {flavor: In the wasteland, power is built on sacrifice, and survival demands it.}
 {a}: You may banish a card from the enemy's void to gain $1. {flavor: What others leave behind, he turns into survival.}
 Dissolve an enemy character with cost $2 or less. $br You may play this event from your void for $0 by abandoning a character.
-{Materialized}, $dissolved: Put the top 4 cards of your deck into your void. {flavor: In the poisoned haze, he searches for remnants of a forgotten world.}
+{Materialized}, {Dissolved}: Put the top 4 cards of your deck into your void. {flavor: In the poisoned haze, he searches for remnants of a forgotten world.}
 Once per turn, when you materialize a {cardtype: survivor}, you may return this character from your void to play.
 {kw: Discover} a {cardtype: survivor}.
 Whenever you play a {cardtype: survivor}, put the top 2 cards of your deck into your void.
@@ -200,4 +200,4 @@ Abandon any number of characters. Draw a card for each character abandoned. {fla
 If you have 8 or more cards in your void, cards in your void have {kw: reclaim}.
 Dissolve an enemy character. Draw a card. $br This event costs $2 less to play for each character which dissolved this turn.
 Abandon a character. Discard your hand. Gain $5. {flavor: A storm answers the call, but only when the price is paid.}
-$judgment: Each player abandons a character. {flavor: To stand against it is to lose yourself, and to flee is to lose everything else.}
+{Judgment}: Each player abandons a character. {flavor: To stand against it is to lose yourself, and to flee is to lose everything else.}

--- a/rules_engine/src/parser/src/trigger_event_parser.rs
+++ b/rules_engine/src/parser/src/trigger_event_parser.rs
@@ -27,8 +27,8 @@ pub fn event_parser<'a>() -> impl Parser<'a, &'a str, TriggerEvent, ErrorType<'a
 pub fn keyword_parser<'a>() -> impl Parser<'a, &'a str, TriggerEvent, ErrorType<'a>> {
     let single_keyword = choice((
         phrase("{materialized}").to(TriggerKeyword::Materialized),
-        phrase("$judgment").to(TriggerKeyword::Judgment),
-        phrase("$dissolved").to(TriggerKeyword::Dissolved),
+        phrase("{judgment}").to(TriggerKeyword::Judgment),
+        phrase("{dissolved}").to(TriggerKeyword::Dissolved),
     ));
 
     single_keyword

--- a/rules_engine/tests/parser_tests/tests/parser_tests/effect_parsing_tests.rs
+++ b/rules_engine/tests/parser_tests/tests/parser_tests/effect_parsing_tests.rs
@@ -1265,7 +1265,7 @@ fn test_discover_multi_activated_ability() {
 
 #[test]
 fn test_each_player_abandons_characters() {
-    let result = parse("$judgment: Each player abandons a character.");
+    let result = parse("{Judgment}: Each player abandons a character.");
     assert_ron_snapshot!(result, @r###"
     [
       Triggered(TriggeredAbility(

--- a/rules_engine/tests/parser_tests/tests/parser_tests/triggered_ability_parsing_tests.rs
+++ b/rules_engine/tests/parser_tests/tests/parser_tests/triggered_ability_parsing_tests.rs
@@ -41,7 +41,7 @@ fn test_keyword_trigger_draw() {
 
 #[test]
 fn test_multiple_keyword_trigger() {
-    let result = parse("{Materialized}, $dissolved: Draw {-drawn-cards(n: 1)}.");
+    let result = parse("{Materialized}, {Dissolved}: Draw {-drawn-cards(n: 1)}.");
     assert_ron_snapshot!(result, @r###"
     [
       Triggered(TriggeredAbility(
@@ -59,7 +59,7 @@ fn test_multiple_keyword_trigger() {
 
 #[test]
 fn test_three_keyword_trigger() {
-    let result = parse("{Materialized}, $judgment, $dissolved: Draw {-drawn-cards(n: 1)}.");
+    let result = parse("{Materialized}, {Judgment}, {Dissolved}: Draw {-drawn-cards(n: 1)}.");
     assert_ron_snapshot!(result, @r###"
     [
       Triggered(TriggeredAbility(
@@ -107,7 +107,7 @@ fn test_once_per_turn() {
 #[test]
 fn test_multiple_keyword_trigger_conditional() {
     let result = parse(
-        "{Materialized}, $judgment: If you control 2 other {cardtype: warriors}, gain {-gained-energy(e: 1)}.",
+        "{Materialized}, {Judgment}: If you control 2 other {cardtype: warriors}, gain {-gained-energy(e: 1)}.",
     );
     assert_ron_snapshot!(
         result,


### PR DESCRIPTION
## Summary
- update the trigger keyword parser to expect `{judgment}` and `{dissolved}` instead of the old `$` syntax
- refresh parser snapshot tests and benchmark ability text examples to the new brace-based trigger notation

## Testing
- just fmt
- just check
- just clippy
- just review

------
https://chatgpt.com/codex/tasks/task_e_68cc47c13aac832f9e3ed651456442c5