### PR TITLE
Add parsing support for card abilities

### DIFF
--- a/rules_engine/src/parser_v2/src/parser/card_predicate_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/card_predicate_parser.rs
@@ -11,6 +11,7 @@ fn card_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserEx
     word("card").to(CardPredicate::Card)
 }
 
-fn subtype_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone {
+fn subtype_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone
+{
     subtype().map(CardPredicate::CharacterType)
 }

--- a/rules_engine/src/parser_v2/src/parser/card_predicate_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/card_predicate_parser.rs
@@ -1,12 +1,16 @@
 use ability_data::predicate::CardPredicate;
 use chumsky::prelude::*;
 
-use crate::parser::parser_helpers::{word, ParserExtra, ParserInput};
+use crate::parser::parser_helpers::{subtype, word, ParserExtra, ParserInput};
 
 pub fn parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone {
-    choice((card_parser(),)).boxed()
+    choice((subtype_parser(), card_parser())).boxed()
 }
 
 fn card_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone {
     word("card").to(CardPredicate::Card)
+}
+
+fn subtype_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone {
+    subtype().map(CardPredicate::CharacterType)
 }

--- a/rules_engine/src/parser_v2/src/parser/effect/card_effect_parsers.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect/card_effect_parsers.rs
@@ -3,13 +3,22 @@ use chumsky::prelude::*;
 use core_data::numerics::{Energy, Points};
 
 use crate::parser::parser_helpers::{
-    cards, discards, energy, period, points, word, ParserExtra, ParserInput,
+    cards, discards, energy, literal_number, period, points, word, ParserExtra, ParserInput,
 };
 
 pub fn draw_cards<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone
 {
     word("draw")
         .ignore_then(cards())
+        .then_ignore(period())
+        .map(|count| StandardEffect::DrawCards { count })
+}
+
+pub fn draw_literal_cards<'a>(
+) -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
+    word("draw")
+        .ignore_then(literal_number())
+        .then_ignore(choice((word("card"), word("cards"))))
         .then_ignore(period())
         .map(|count| StandardEffect::DrawCards { count })
 }

--- a/rules_engine/src/parser_v2/src/parser/effect/game_effects_parsers.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect/game_effects_parsers.rs
@@ -1,1 +1,37 @@
+use ability_data::standard_effect::StandardEffect;
+use chumsky::prelude::*;
 
+use crate::parser::card_predicate_parser;
+use crate::parser::parser_helpers::{directive, foresee_count, period, word, ParserExtra, ParserInput};
+use crate::parser::predicate_parser;
+
+pub fn foresee<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
+    foresee_count()
+        .then_ignore(period())
+        .map(|count| StandardEffect::Foresee { count })
+}
+
+pub fn discover<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
+    directive("discover")
+        .ignore_then(card_predicate_parser::parser())
+        .then_ignore(period())
+        .map(|predicate| StandardEffect::Discover { predicate })
+}
+
+pub fn counterspell<'a>(
+) -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
+    directive("prevent")
+        .ignore_then(word("a"))
+        .ignore_then(predicate_parser::predicate_parser())
+        .then_ignore(period())
+        .map(|target| StandardEffect::Counterspell { target })
+}
+
+pub fn dissolve_character<'a>(
+) -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
+    directive("dissolve")
+        .ignore_then(word("an"))
+        .ignore_then(predicate_parser::predicate_parser())
+        .then_ignore(period())
+        .map(|target| StandardEffect::DissolveCharacter { target })
+}

--- a/rules_engine/src/parser_v2/src/parser/effect/game_effects_parsers.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect/game_effects_parsers.rs
@@ -1,14 +1,13 @@
 use ability_data::standard_effect::StandardEffect;
 use chumsky::prelude::*;
 
-use crate::parser::card_predicate_parser;
-use crate::parser::parser_helpers::{directive, foresee_count, period, word, ParserExtra, ParserInput};
-use crate::parser::predicate_parser;
+use crate::parser::parser_helpers::{
+    directive, foresee_count, period, word, ParserExtra, ParserInput,
+};
+use crate::parser::{card_predicate_parser, predicate_parser};
 
 pub fn foresee<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
-    foresee_count()
-        .then_ignore(period())
-        .map(|count| StandardEffect::Foresee { count })
+    foresee_count().then_ignore(period()).map(|count| StandardEffect::Foresee { count })
 }
 
 pub fn discover<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {

--- a/rules_engine/src/parser_v2/src/parser/effect/spark_effect_parsers.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect/spark_effect_parsers.rs
@@ -1,1 +1,11 @@
+use ability_data::standard_effect::StandardEffect;
+use chumsky::prelude::*;
+use core_data::numerics::Spark;
 
+use crate::parser::parser_helpers::{kindle_amount, period, ParserExtra, ParserInput};
+
+pub fn kindle<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
+    kindle_amount()
+        .then_ignore(period())
+        .map(|amount| StandardEffect::Kindle { amount: Spark(amount) })
+}

--- a/rules_engine/src/parser_v2/src/parser/effect_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect_parser.rs
@@ -1,16 +1,22 @@
 use ability_data::standard_effect::StandardEffect;
 use chumsky::prelude::*;
 
-use crate::parser::effect::card_effect_parsers;
+use crate::parser::effect::{card_effect_parsers, game_effects_parsers, spark_effect_parsers};
 use crate::parser::parser_helpers::{ParserExtra, ParserInput};
 
 pub fn single_effect_parser<'a>(
 ) -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
     choice((
         card_effect_parsers::draw_cards(),
+        card_effect_parsers::draw_literal_cards(),
         card_effect_parsers::discard_cards(),
         card_effect_parsers::gain_energy(),
         card_effect_parsers::gain_points(),
+        game_effects_parsers::foresee(),
+        game_effects_parsers::discover(),
+        game_effects_parsers::counterspell(),
+        game_effects_parsers::dissolve_character(),
+        spark_effect_parsers::kindle(),
     ))
     .boxed()
 }

--- a/rules_engine/src/parser_v2/src/parser/parser_helpers.rs
+++ b/rules_engine/src/parser_v2/src/parser/parser_helpers.rs
@@ -77,3 +77,21 @@ pub fn words<'a>(
 ) -> impl Parser<'a, ParserInput<'a>, (), ParserExtra<'a>> + Clone {
     sequence.iter().fold(empty().boxed(), |acc, &w| acc.then_ignore(word(w)).boxed())
 }
+
+pub fn literal_number<'a>() -> impl Parser<'a, ParserInput<'a>, u32, ParserExtra<'a>> + Clone {
+    select! {
+        (ResolvedToken::Token(Token::Word(w)), _) if w.parse::<u32>().is_ok() => w.parse::<u32>().unwrap()
+    }
+}
+
+pub fn foresee_count<'a>() -> impl Parser<'a, ParserInput<'a>, u32, ParserExtra<'a>> + Clone {
+    select! {
+        (ResolvedToken::Integer { directive, value }, _) if directive == "foresee" || directive == "Foresee" => value
+    }
+}
+
+pub fn kindle_amount<'a>() -> impl Parser<'a, ParserInput<'a>, u32, ParserExtra<'a>> + Clone {
+    select! {
+        (ResolvedToken::Integer { directive, value }, _) if directive == "kindle" || directive == "Kindle" => value
+    }
+}

--- a/rules_engine/src/parser_v2/src/parser/predicate_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/predicate_parser.rs
@@ -1,11 +1,12 @@
-use ability_data::predicate::Predicate;
+use ability_data::predicate::{CardPredicate, Predicate};
 use chumsky::prelude::*;
 
-use crate::parser::parser_helpers::{words, ParserExtra, ParserInput};
+use crate::parser::card_predicate_parser;
+use crate::parser::parser_helpers::{word, words, ParserExtra, ParserInput};
 
 pub fn predicate_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<'a>> + Clone
 {
-    choice((this_parser(),)).boxed()
+    choice((this_parser(), enemy_parser(), any_card_parser())).boxed()
 }
 
 fn this_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<'a>> + Clone {
@@ -14,4 +15,14 @@ fn this_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<
         words(&["this", "event"]).to(Predicate::This),
         words(&["this", "card"]).to(Predicate::This),
     ))
+}
+
+fn enemy_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<'a>> + Clone {
+    word("enemy")
+        .ignore_then(card_predicate_parser::parser().or_not())
+        .map(|pred| Predicate::Enemy(pred.unwrap_or(CardPredicate::Character)))
+}
+
+fn any_card_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<'a>> + Clone {
+    word("card").map(|_| Predicate::Any(CardPredicate::Card))
 }

--- a/rules_engine/src/parser_v2/src/serializer/parser_formatter.rs
+++ b/rules_engine/src/parser_v2/src/serializer/parser_formatter.rs
@@ -20,6 +20,13 @@ pub fn serialize_ability(ability: &Ability) -> String {
             }
             result
         }
+        Ability::Event(event) => {
+            if let ability_data::effect::Effect::Effect(effect) = &event.effect {
+                capitalize_first_letter(&serialize_standard_effect(effect))
+            } else {
+                unimplemented!("Serialization not yet implemented for complex event effects")
+            }
+        }
         _ => unimplemented!("Serialization not yet implemented for this ability type"),
     }
 }
@@ -30,6 +37,17 @@ pub fn serialize_standard_effect(effect: &StandardEffect) -> String {
         StandardEffect::DiscardCards { .. } => "discard {discards}.".to_string(),
         StandardEffect::GainEnergy { .. } => "gain {e}.".to_string(),
         StandardEffect::GainPoints { .. } => "gain {points}.".to_string(),
+        StandardEffect::Foresee { .. } => "{Foresee}.".to_string(),
+        StandardEffect::Kindle { .. } => "{Kindle}.".to_string(),
+        StandardEffect::Counterspell { target } => {
+            format!("{{Prevent}} {}.", serialize_predicate(target))
+        }
+        StandardEffect::DissolveCharacter { target } => {
+            format!("{{Dissolve}} {}.", serialize_predicate(target))
+        }
+        StandardEffect::Discover { predicate } => {
+            format!("{{Discover}} {}.", serialize_card_predicate(predicate))
+        }
         _ => unimplemented!("Serialization not yet implemented for this effect type"),
     }
 }
@@ -98,6 +116,9 @@ fn serialize_predicate(predicate: &Predicate) -> String {
             format!("an {}", serialize_your_predicate(card_predicate))
         }
         Predicate::Any(card_predicate) => serialize_card_predicate(card_predicate),
+        Predicate::Enemy(card_predicate) => {
+            format!("an {}", serialize_enemy_predicate(card_predicate))
+        }
         _ => unimplemented!("Serialization not yet implemented for this predicate type"),
     }
 }
@@ -109,11 +130,19 @@ fn serialize_your_predicate(card_predicate: &CardPredicate) -> String {
     }
 }
 
+fn serialize_enemy_predicate(card_predicate: &CardPredicate) -> String {
+    match card_predicate {
+        CardPredicate::Character => "enemy".to_string(),
+        _ => unimplemented!("Serialization not yet implemented for this enemy predicate type"),
+    }
+}
+
 fn serialize_card_predicate(card_predicate: &CardPredicate) -> String {
     match card_predicate {
         CardPredicate::Card => "a card".to_string(),
         CardPredicate::Character => "a character".to_string(),
         CardPredicate::Event => "an event".to_string(),
+        CardPredicate::CharacterType(_) => "{a-subtype}".to_string(),
         _ => {
             unimplemented!("Serialization not yet implemented for this card predicate type")
         }

--- a/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
@@ -1,0 +1,142 @@
+use insta::assert_ron_snapshot;
+use parser_v2_tests::test_helpers::*;
+
+#[test]
+fn test_judgment_gain_points() {
+    let result = parse_ability("{Judgment} Gain {points}.", "points: 2");
+    assert_ron_snapshot!(result, @r###"
+    Triggered(TriggeredAbility(
+      trigger: Keywords([
+        Judgment,
+      ]),
+      effect: Effect(GainPoints(
+        gains: Points(2),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_judgment_foresee() {
+    let result = parse_ability("{Judgment} {Foresee}.", "foresee: 3");
+    assert_ron_snapshot!(result, @r###"
+    Triggered(TriggeredAbility(
+      trigger: Keywords([
+        Judgment,
+      ]),
+      effect: Effect(Foresee(
+        count: 3,
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_materialized_draw_cards() {
+    let result = parse_ability("{Materialized} Draw {cards}.", "cards: 1");
+    assert_ron_snapshot!(result, @r###"
+    Triggered(TriggeredAbility(
+      trigger: Keywords([
+        Materialized,
+      ]),
+      effect: Effect(DrawCards(
+        count: 1,
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_materialized_foresee() {
+    let result = parse_ability("{Materialized} {Foresee}.", "foresee: 3");
+    assert_ron_snapshot!(result, @r###"
+    Triggered(TriggeredAbility(
+      trigger: Keywords([
+        Materialized,
+      ]),
+      effect: Effect(Foresee(
+        count: 3,
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_materialized_judgment_kindle() {
+    let result = parse_ability("{MaterializedJudgment} {Kindle}.", "k: 1");
+    assert_ron_snapshot!(result, @r###"
+    Triggered(TriggeredAbility(
+      trigger: Keywords([
+        Materialized,
+        Judgment,
+      ]),
+      effect: Effect(Kindle(
+        amount: Spark(1),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_materialized_judgment_gain_energy() {
+    let result = parse_ability("{MaterializedJudgment} Gain {e}.", "e: 1");
+    assert_ron_snapshot!(result, @r###"
+    Triggered(TriggeredAbility(
+      trigger: Keywords([
+        Materialized,
+        Judgment,
+      ]),
+      effect: Effect(GainEnergy(
+        gains: Energy(1),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_prevent_a_card() {
+    let result = parse_ability("{Prevent} a card.", "");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(Counterspell(
+        target: Any(Card),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_dissolve_an_enemy() {
+    let result = parse_ability("{Dissolve} an enemy.", "");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(DissolveCharacter(
+        target: Enemy(Character),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_discover_a_subtype() {
+    let result = parse_ability("{Discover} {a-subtype}.", "subtype: warrior");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(Discover(
+        predicate: CharacterType(Warrior),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_draw_literal_cards() {
+    let result = parse_ability("Draw 3 cards.", "");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(DrawCards(
+        count: 3,
+      )),
+    ))
+    "###);
+}


### PR DESCRIPTION
Implements parsing for 10 new card ability patterns:
- {Judgment} Gain {points}
- {Judgment} {Foresee}
- {Materialized} Draw {cards}
- {Materialized} {Foresee}
- {MaterializedJudgment} {Kindle}
- {MaterializedJudgment} Gain {e}
- {Prevent} a card
- {Dissolve} an enemy
- {Discover} {a-subtype}
- Draw 3 cards

Changes include:
- Added game effect parsers for Foresee, Discover, Counterspell (Prevent), and DissolveCharacter
- Added spark effect parser for Kindle
- Added support for literal number parsing in draw cards
- Extended predicate parser to handle "enemy" and "card" predicates
- Extended card predicate parser to handle subtype variables
- Added helper functions for foresee_count and kindle_amount
- Updated serialization support for all new effects
- Added comprehensive test suite with 10 passing tests

All tests pass and the project compiles successfully.