### PR TITLE
Add parsing support for compound effects: "Gain {e}. Draw {cards}."

### DIFF
--- a/rules_engine/docs/rules_text_sorted.json
+++ b/rules_engine/docs/rules_text_sorted.json
@@ -11,7 +11,7 @@
   "{Prevent} a card.", // Implemented
   "{Dissolve} an enemy.", // Implemented
   "{Discover} {a-subtype}.", // Implemented
-  "Gain {e}. Draw {cards}.",
+  "Gain {e}. Draw {cards}.", // Implemented
   "Draw {cards}. Discard {discards}.",
   "Draw {cards}. Discard {discards}. Gain {e}.",
   "Discard {discards}. Draw {cards}.",

--- a/rules_engine/src/parser_v2/src/parser/ability_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/ability_parser.rs
@@ -1,5 +1,4 @@
 use ability_data::ability::{Ability, EventAbility};
-use ability_data::effect::Effect;
 use chumsky::prelude::*;
 
 use crate::parser::parser_helpers::{ParserExtra, ParserInput};
@@ -16,10 +15,6 @@ fn triggered_ability_parser<'a>(
 
 fn event_ability_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Ability, ParserExtra<'a>> + Clone
 {
-    effect_parser::single_effect_parser().map(|standard_effect| {
-        Ability::Event(EventAbility {
-            additional_cost: None,
-            effect: Effect::Effect(standard_effect),
-        })
-    })
+    effect_parser::effect_or_compound_parser()
+        .map(|effect| Ability::Event(EventAbility { additional_cost: None, effect }))
 }

--- a/rules_engine/src/parser_v2/src/parser/effect_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect_parser.rs
@@ -1,3 +1,4 @@
+use ability_data::effect::{Effect, EffectWithOptions};
 use ability_data::standard_effect::StandardEffect;
 use chumsky::prelude::*;
 
@@ -12,4 +13,20 @@ pub fn single_effect_parser<'a>(
         spark_effect_parsers::parser(),
     ))
     .boxed()
+}
+
+pub fn effect_or_compound_parser<'a>(
+) -> impl Parser<'a, ParserInput<'a>, Effect, ParserExtra<'a>> + Clone {
+    single_effect_parser()
+        .repeated()
+        .at_least(1)
+        .collect::<Vec<_>>()
+        .map(|effects| {
+            if effects.len() == 1 {
+                Effect::Effect(effects.into_iter().next().unwrap())
+            } else {
+                Effect::List(effects.into_iter().map(EffectWithOptions::new).collect())
+            }
+        })
+        .boxed()
 }

--- a/rules_engine/src/parser_v2/src/parser/triggered_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/triggered_parser.rs
@@ -1,4 +1,3 @@
-use ability_data::effect::Effect;
 use ability_data::triggered_ability::{TriggeredAbility, TriggeredAbilityOptions};
 use chumsky::prelude::*;
 
@@ -17,10 +16,10 @@ fn once_per_turn_triggered<'a>(
         .ignore_then(word("turn"))
         .ignore_then(comma())
         .ignore_then(trigger_parser::trigger_event_parser())
-        .then(effect_parser::single_effect_parser())
+        .then(effect_parser::effect_or_compound_parser())
         .map(|(trigger, effect)| TriggeredAbility {
             trigger,
-            effect: Effect::Effect(effect),
+            effect,
             options: Some(TriggeredAbilityOptions {
                 once_per_turn: true,
                 until_end_of_turn: false,
@@ -30,11 +29,7 @@ fn once_per_turn_triggered<'a>(
 
 fn simple_triggered<'a>(
 ) -> impl Parser<'a, ParserInput<'a>, TriggeredAbility, ParserExtra<'a>> + Clone {
-    trigger_parser::trigger_event_parser().then(effect_parser::single_effect_parser()).map(
-        |(trigger, effect)| TriggeredAbility {
-            trigger,
-            effect: Effect::Effect(effect),
-            options: None,
-        },
-    )
+    trigger_parser::trigger_event_parser()
+        .then(effect_parser::effect_or_compound_parser())
+        .map(|(trigger, effect)| TriggeredAbility { trigger, effect, options: None })
 }

--- a/rules_engine/src/parser_v2/src/serializer/parser_formatter.rs
+++ b/rules_engine/src/parser_v2/src/serializer/parser_formatter.rs
@@ -1,4 +1,5 @@
 use ability_data::ability::Ability;
+use ability_data::effect::Effect;
 use ability_data::predicate::{CardPredicate, Predicate};
 use ability_data::standard_effect::StandardEffect;
 use ability_data::trigger_event::{TriggerEvent, TriggerKeyword};
@@ -21,18 +22,10 @@ pub fn serialize_ability(ability: &Ability) -> String {
                 result.push(' ');
             }
 
-            if let ability_data::effect::Effect::Effect(effect) = &triggered.effect {
-                result.push_str(&serialize_standard_effect(effect));
-            }
+            result.push_str(&serialize_effect(&triggered.effect));
             result
         }
-        Ability::Event(event) => {
-            if let ability_data::effect::Effect::Effect(effect) = &event.effect {
-                capitalize_first_letter(&serialize_standard_effect(effect))
-            } else {
-                unimplemented!("Serialization not yet implemented for complex event effects")
-            }
-        }
+        Ability::Event(event) => capitalize_first_letter(&serialize_effect(&event.effect)),
         _ => unimplemented!("Serialization not yet implemented for this ability type"),
     }
 }
@@ -96,6 +89,18 @@ pub fn serialize_trigger_event(trigger: &TriggerEvent) -> String {
         }
         TriggerEvent::GainEnergy => "when you gain energy, ".to_string(),
         _ => unimplemented!("Serialization not yet implemented for this trigger type"),
+    }
+}
+
+fn serialize_effect(effect: &Effect) -> String {
+    match effect {
+        Effect::Effect(standard_effect) => serialize_standard_effect(standard_effect),
+        Effect::List(effects) => effects
+            .iter()
+            .map(|e| capitalize_first_letter(&serialize_standard_effect(&e.effect)))
+            .collect::<Vec<_>>()
+            .join(" "),
+        _ => unimplemented!("Serialization not yet implemented for this effect type"),
     }
 }
 

--- a/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests.rs
@@ -80,3 +80,19 @@ fn test_round_trip_materialized_judgment_kindle() {
     let serialized = parser_formatter::serialize_ability(&parsed);
     assert_eq!(original, serialized);
 }
+
+#[test]
+fn test_round_trip_gain_energy_draw_cards() {
+    let original = "Gain {e}. Draw {cards}.";
+    let parsed = parse_ability(original, "e: 2, cards: 3");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}
+
+#[test]
+fn test_round_trip_judgment_gain_energy_draw_cards() {
+    let original = "{Judgment} Gain {e}. Draw {cards}.";
+    let parsed = parse_ability(original, "e: 1, cards: 2");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
@@ -140,3 +140,52 @@ fn test_draw_cards_event() {
     ))
     "###);
 }
+
+#[test]
+fn test_gain_energy_draw_cards() {
+    let result = parse_ability("Gain {e}. Draw {cards}.", "e: 2, cards: 3");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: List([
+        EffectWithOptions(
+          effect: GainEnergy(
+            gains: Energy(2),
+          ),
+          optional: false,
+        ),
+        EffectWithOptions(
+          effect: DrawCards(
+            count: 3,
+          ),
+          optional: false,
+        ),
+      ]),
+    ))
+    "###);
+}
+
+#[test]
+fn test_judgment_gain_energy_draw_cards() {
+    let result = parse_ability("{Judgment} Gain {e}. Draw {cards}.", "e: 1, cards: 2");
+    assert_ron_snapshot!(result, @r###"
+    Triggered(TriggeredAbility(
+      trigger: Keywords([
+        Judgment,
+      ]),
+      effect: List([
+        EffectWithOptions(
+          effect: GainEnergy(
+            gains: Energy(1),
+          ),
+          optional: false,
+        ),
+        EffectWithOptions(
+          effect: DrawCards(
+            count: 2,
+          ),
+          optional: false,
+        ),
+      ]),
+    ))
+    "###);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/spanned_ability_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/spanned_ability_tests.rs
@@ -97,3 +97,38 @@ fn test_parse_activated_ability() {
     assert!(text.text.contains("Draw 2."));
     assert_valid_span(&text.span);
 }
+
+#[test]
+fn test_spanned_compound_effect_event() {
+    let SpannedAbility::Event(event) =
+        parse_spanned_ability("Gain {e}. Draw {cards}.", "e: 2, cards: 3")
+    else {
+        panic!("Expected Event ability");
+    };
+
+    assert_eq!(event.additional_cost, None);
+    let SpannedEffect::Effect(effect) = &event.effect else {
+        panic!("Expected Effect, got Modal");
+    };
+    assert_eq!(effect.text.trim(), "Gain {e}. Draw {cards}.");
+    assert_valid_span(&effect.span);
+}
+
+#[test]
+fn test_spanned_compound_effect_triggered() {
+    let SpannedAbility::Triggered(triggered) =
+        parse_spanned_ability("{Judgment} Gain {e}. Draw {cards}.", "e: 1, cards: 2")
+    else {
+        panic!("Expected Triggered ability");
+    };
+
+    assert_eq!(triggered.once_per_turn, None);
+    assert_eq!(triggered.trigger.text, "{Judgment}");
+    assert_valid_span(&triggered.trigger.span);
+
+    let SpannedEffect::Effect(effect) = &triggered.effect else {
+        panic!("Expected Effect, got Modal");
+    };
+    assert_eq!(effect.text.trim(), "Gain {e}. Draw {cards}.");
+    assert_valid_span(&effect.span);
+}


### PR DESCRIPTION
This commit implements parsing for compound effects that consist of multiple
simple effects separated by periods. The implementation allows both event
abilities and triggered abilities to use compound effects.

Changes:
- Modified effect_parser.rs to add effect_or_compound_parser() which handles
  both single effects and compound effects (Effect::List)
- Updated ability_parser.rs to use effect_or_compound_parser() for event abilities
- Updated triggered_parser.rs to support compound effects in triggered abilities
- Enhanced serializer to properly serialize compound effects with capitalization
- Added comprehensive tests for parsing, round-trip, and spanned abilities
- Marked "Gain {e}. Draw {cards}." as implemented in rules_text_sorted.json

All parser_v2_tests pass successfully.