### PR TITLE
Add parsing support for draw/discard compound effects

### DIFF
--- a/rules_engine/docs/adding_parsers.md
+++ b/rules_engine/docs/adding_parsers.md
@@ -1265,11 +1265,27 @@ Draw {cards}.
 ```
 
 ### Compound Effects
+
+**IMPORTANT**: Compound effects (multiple effects separated by periods) are automatically
+supported through the `effect_or_compound_parser` in `effect_parser.rs`. You typically
+do NOT need to write a special parser for compound effects.
+
+When you implement a single effect parser (e.g., `draw_cards()`, `discard_cards()`), it
+automatically works in compound effect patterns:
+
 ```
-Gain {e}. Draw {cards}.
-Draw {cards}. Discard {discards}.
-{Dissolve} an enemy. You lose {points}.
+Gain {e}. Draw {cards}.           // Automatically works
+Draw {cards}. Discard {discards}. // Automatically works
+Discard {discards}. Draw {cards}. // Automatically works
+{Dissolve} an enemy. You lose {points}. // Automatically works
 ```
+
+The `effect_or_compound_parser` uses `.repeated().at_least(1)` to parse multiple effects
+and combines them into `Effect::List`. Serialization, spanned abilities, and round-trip
+support all handle compound effects automatically.
+
+**When implementing new effects**: Focus on implementing the single effect parser correctly.
+Test both the standalone effect AND compound variations to ensure proper integration.
 
 ### Triggers with Conditions
 ```

--- a/rules_engine/docs/adding_parsers.md
+++ b/rules_engine/docs/adding_parsers.md
@@ -409,9 +409,19 @@ Available test helpers in `test_helpers.rs`:
 | `parse_ability(input, vars)` | Parse to `Ability` |
 | `parse_spanned_ability(input, vars)` | Parse to `SpannedAbility` |
 
-Run tests with:
+**IMPORTANT**: All cargo commands must be run from the `rules_engine` directory:
+
 ```bash
-cargo test -p parser_v2_tests
+cd /home/user/dreamtides/rules_engine  # Or your repo path
+cargo test -p parser_v2_tests           # Run all parser_v2 tests
+```
+
+Run specific test files:
+```bash
+cargo test -p parser_v2_tests --test effect_parser_tests
+cargo test -p parser_v2_tests --test ability_round_trip_tests
+cargo test -p parser_v2_tests --test spanned_ability_tests
+cargo test -p parser_v2_tests --test parse_error_tests
 ```
 
 Update snapshots with:
@@ -1322,13 +1332,19 @@ This character's spark is equal to the number of cards in your void.
 
 ## Validation Commands Reference
 
+**IMPORTANT**: All commands must be run from the `rules_engine` directory. Change to this directory first:
+```bash
+cd /home/user/dreamtides/rules_engine  # Or wherever your repo is located
+```
+
 | Command | Purpose |
 |---------|---------|
 | `just fmt` | Apply rustfmt formatting |
 | `just check` | Type check code |
 | `just clippy` | Check for lint warnings |
-| `cargo test -p parser_v2_tests` | Run parser tests |
-| `just review` | Full validation pipeline |
+| `cargo test -p parser_v2_tests` | Run all parser tests |
+| `cargo test -p parser_v2_tests --test effect_parser_tests` | Run specific test file |
+| `just review` | Full validation pipeline (fmt check, build, lint, clippy, test) |
 | `cargo insta review` | Review/update snapshots |
 
 ---

--- a/rules_engine/docs/rules_text_sorted.json
+++ b/rules_engine/docs/rules_text_sorted.json
@@ -12,9 +12,9 @@
   "{Dissolve} an enemy.", // Implemented
   "{Discover} {a-subtype}.", // Implemented
   "Gain {e}. Draw {cards}.", // Implemented
-  "Draw {cards}. Discard {discards}.",
-  "Draw {cards}. Discard {discards}. Gain {e}.",
-  "Discard {discards}. Draw {cards}.",
+  "Draw {cards}. Discard {discards}.", // Implemented
+  "Draw {cards}. Discard {discards}. Gain {e}.", // Implemented
+  "Discard {discards}. Draw {cards}.", // Implemented
   "{Dissolve} an enemy. You lose {points}.",
   "{Dissolve} an enemy. The opponent gains {points}.",
   "{Judgment} Draw {cards}. The opponent gains {points}.",

--- a/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests.rs
@@ -96,3 +96,27 @@ fn test_round_trip_judgment_gain_energy_draw_cards() {
     let serialized = parser_formatter::serialize_ability(&parsed);
     assert_eq!(original, serialized);
 }
+
+#[test]
+fn test_round_trip_draw_cards_discard_cards() {
+    let original = "Draw {cards}. Discard {discards}.";
+    let parsed = parse_ability(original, "cards: 2, discards: 1");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}
+
+#[test]
+fn test_round_trip_draw_cards_discard_cards_gain_energy() {
+    let original = "Draw {cards}. Discard {discards}. Gain {e}.";
+    let parsed = parse_ability(original, "cards: 1, discards: 1, e: 1");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}
+
+#[test]
+fn test_round_trip_discard_cards_draw_cards() {
+    let original = "Discard {discards}. Draw {cards}.";
+    let parsed = parse_ability(original, "discards: 1, cards: 2");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
@@ -189,3 +189,79 @@ fn test_judgment_gain_energy_draw_cards() {
     ))
     "###);
 }
+
+#[test]
+fn test_draw_cards_discard_cards() {
+    let result = parse_ability("Draw {cards}. Discard {discards}.", "cards: 2, discards: 1");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: List([
+        EffectWithOptions(
+          effect: DrawCards(
+            count: 2,
+          ),
+          optional: false,
+        ),
+        EffectWithOptions(
+          effect: DiscardCards(
+            count: 1,
+          ),
+          optional: false,
+        ),
+      ]),
+    ))
+    "###);
+}
+
+#[test]
+fn test_draw_cards_discard_cards_gain_energy() {
+    let result =
+        parse_ability("Draw {cards}. Discard {discards}. Gain {e}.", "cards: 1, discards: 1, e: 1");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: List([
+        EffectWithOptions(
+          effect: DrawCards(
+            count: 1,
+          ),
+          optional: false,
+        ),
+        EffectWithOptions(
+          effect: DiscardCards(
+            count: 1,
+          ),
+          optional: false,
+        ),
+        EffectWithOptions(
+          effect: GainEnergy(
+            gains: Energy(1),
+          ),
+          optional: false,
+        ),
+      ]),
+    ))
+    "###);
+}
+
+#[test]
+fn test_discard_cards_draw_cards() {
+    let result = parse_ability("Discard {discards}. Draw {cards}.", "discards: 1, cards: 2");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: List([
+        EffectWithOptions(
+          effect: DiscardCards(
+            count: 1,
+          ),
+          optional: false,
+        ),
+        EffectWithOptions(
+          effect: DrawCards(
+            count: 2,
+          ),
+          optional: false,
+        ),
+      ]),
+    ))
+    "###);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/parse_error_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/parse_error_tests.rs
@@ -188,3 +188,19 @@ fn test_incomplete_predicate() {
 
     assert!(result.is_err());
 }
+
+#[test]
+fn test_draw_discard_missing_variables_suggests_fix() {
+    let input = "Draw {cards}. Discard {discards}.";
+    let lex_result = lexer_tokenize::lex(input).unwrap();
+    let bindings = VariableBindings::new();
+
+    let result = parser_substitutions::resolve_variables(&lex_result.tokens, &bindings);
+
+    assert!(result.is_err());
+    let error = ParserError::from(result.unwrap_err());
+    let formatted = parser_diagnostics::format_error(&error, input, "test");
+
+    assert!(formatted.contains("cards"));
+    assert!(formatted.contains("not found"));
+}

--- a/rules_engine/tests/parser_v2_tests/tests/spanned_ability_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/spanned_ability_tests.rs
@@ -132,3 +132,52 @@ fn test_spanned_compound_effect_triggered() {
     assert_eq!(effect.text.trim(), "Gain {e}. Draw {cards}.");
     assert_valid_span(&effect.span);
 }
+
+#[test]
+fn test_spanned_draw_cards_discard_cards() {
+    let SpannedAbility::Event(event) =
+        parse_spanned_ability("Draw {cards}. Discard {discards}.", "cards: 2, discards: 1")
+    else {
+        panic!("Expected Event ability");
+    };
+
+    assert_eq!(event.additional_cost, None);
+    let SpannedEffect::Effect(effect) = &event.effect else {
+        panic!("Expected Effect, got Modal");
+    };
+    assert_eq!(effect.text.trim(), "Draw {cards}. Discard {discards}.");
+    assert_valid_span(&effect.span);
+}
+
+#[test]
+fn test_spanned_draw_cards_discard_cards_gain_energy() {
+    let SpannedAbility::Event(event) = parse_spanned_ability(
+        "Draw {cards}. Discard {discards}. Gain {e}.",
+        "cards: 1, discards: 1, e: 1",
+    ) else {
+        panic!("Expected Event ability");
+    };
+
+    assert_eq!(event.additional_cost, None);
+    let SpannedEffect::Effect(effect) = &event.effect else {
+        panic!("Expected Effect, got Modal");
+    };
+    assert_eq!(effect.text.trim(), "Draw {cards}. Discard {discards}. Gain {e}.");
+    assert_valid_span(&effect.span);
+}
+
+#[test]
+fn test_spanned_discard_cards_draw_cards() {
+    let SpannedAbility::Event(event) =
+        parse_spanned_ability("Discard {discards}. Draw {cards}.", "discards: 1, cards: 2")
+    else {
+        panic!("Expected Event ability");
+    };
+
+    assert_eq!(event.additional_cost, None);
+    let SpannedEffect::Effect(effect) = &event.effect else {
+        panic!("Expected Effect, got Modal");
+    };
+    assert_eq!(effect.text.trim(), "Discard {discards}. Draw {cards}.");
+    assert_valid_span(&effect.span);
+}


### PR DESCRIPTION
This commit adds comprehensive test coverage for three new card ability
patterns that combine draw and discard actions:
- "Draw {cards}. Discard {discards}."
- "Draw {cards}. Discard {discards}. Gain {e}."
- "Discard {discards}. Draw {cards}."

Changes:
- Added parsing tests with insta snapshots (effect_parser_tests.rs)
- Added round-trip serialization tests (ability_round_trip_tests.rs)
- Added spanned ability tests (spanned_ability_tests.rs)
- Added error handling test for missing variables (parse_error_tests.rs)
- Marked patterns as implemented in rules_text_sorted.json
- Updated documentation with compound effect implementation notes

Implementation note: These patterns work automatically through the existing
effect_or_compound_parser which uses .repeated().at_least(1) to parse
multiple effects and combine them into Effect::List. No new parser code
was required - only comprehensive test coverage.

All tests pass with 'just review'.