### PR TITLE
Add parsing support for opponent gains/you lose points effects

### DIFF
--- a/rules_engine/docs/rules_text_sorted.json
+++ b/rules_engine/docs/rules_text_sorted.json
@@ -15,9 +15,9 @@
   "Draw {cards}. Discard {discards}.", // Implemented
   "Draw {cards}. Discard {discards}. Gain {e}.", // Implemented
   "Discard {discards}. Draw {cards}.", // Implemented
-  "{Dissolve} an enemy. You lose {points}.",
-  "{Dissolve} an enemy. The opponent gains {points}.",
-  "{Judgment} Draw {cards}. The opponent gains {points}.",
+  "{Dissolve} an enemy. You lose {points}.", // Implemented
+  "{Dissolve} an enemy. The opponent gains {points}.", // Implemented
+  "{Judgment} Draw {cards}. The opponent gains {points}.", // Implemented
   "Return an enemy or ally to hand. Draw {cards}.",
   "{Dissolve} an enemy with spark {s} or less.",
   "{Dissolve} an enemy with spark {s} or more.",

--- a/rules_engine/src/parser_v2/src/parser/effect/resource_effect_parsers.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect/resource_effect_parsers.rs
@@ -1,1 +1,27 @@
+use ability_data::standard_effect::StandardEffect;
+use chumsky::prelude::*;
+use core_data::numerics::Points;
 
+use crate::parser::parser_helpers::{period, points, word, words, ParserExtra, ParserInput};
+
+pub fn parser<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
+    choice((lose_points(), enemy_gains_points())).boxed()
+}
+
+pub fn lose_points<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone
+{
+    word("you")
+        .ignore_then(word("lose"))
+        .ignore_then(points())
+        .then_ignore(period())
+        .map(|n| StandardEffect::LosePoints { loses: Points(n) })
+}
+
+pub fn enemy_gains_points<'a>(
+) -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
+    words(&["the", "opponent"])
+        .ignore_then(word("gains"))
+        .ignore_then(points())
+        .then_ignore(period())
+        .map(|count| StandardEffect::EnemyGainsPoints { count })
+}

--- a/rules_engine/src/parser_v2/src/parser/effect/resource_effect_parsers.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect/resource_effect_parsers.rs
@@ -2,7 +2,7 @@ use ability_data::standard_effect::StandardEffect;
 use chumsky::prelude::*;
 use core_data::numerics::Points;
 
-use crate::parser::parser_helpers::{period, points, word, words, ParserExtra, ParserInput};
+use crate::parser::parser_helpers::{period, points, words, ParserExtra, ParserInput};
 
 pub fn parser<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
     choice((lose_points(), enemy_gains_points())).boxed()
@@ -10,8 +10,7 @@ pub fn parser<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserEx
 
 pub fn lose_points<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone
 {
-    word("you")
-        .ignore_then(word("lose"))
+    words(&["you", "lose"])
         .ignore_then(points())
         .then_ignore(period())
         .map(|n| StandardEffect::LosePoints { loses: Points(n) })
@@ -19,8 +18,7 @@ pub fn lose_points<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, Par
 
 pub fn enemy_gains_points<'a>(
 ) -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
-    words(&["the", "opponent"])
-        .ignore_then(word("gains"))
+    words(&["the", "opponent", "gains"])
         .ignore_then(points())
         .then_ignore(period())
         .map(|count| StandardEffect::EnemyGainsPoints { count })

--- a/rules_engine/src/parser_v2/src/parser/effect_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect_parser.rs
@@ -2,7 +2,9 @@ use ability_data::effect::{Effect, EffectWithOptions};
 use ability_data::standard_effect::StandardEffect;
 use chumsky::prelude::*;
 
-use crate::parser::effect::{card_effect_parsers, game_effects_parsers, spark_effect_parsers};
+use crate::parser::effect::{
+    card_effect_parsers, game_effects_parsers, resource_effect_parsers, spark_effect_parsers,
+};
 use crate::parser::parser_helpers::{ParserExtra, ParserInput};
 
 pub fn single_effect_parser<'a>(
@@ -10,6 +12,7 @@ pub fn single_effect_parser<'a>(
     choice((
         card_effect_parsers::parser(),
         game_effects_parsers::parser(),
+        resource_effect_parsers::parser(),
         spark_effect_parsers::parser(),
     ))
     .boxed()

--- a/rules_engine/src/parser_v2/src/serializer/parser_formatter.rs
+++ b/rules_engine/src/parser_v2/src/serializer/parser_formatter.rs
@@ -36,6 +36,8 @@ pub fn serialize_standard_effect(effect: &StandardEffect) -> String {
         StandardEffect::DiscardCards { .. } => "discard {discards}.".to_string(),
         StandardEffect::GainEnergy { .. } => "gain {e}.".to_string(),
         StandardEffect::GainPoints { .. } => "gain {points}.".to_string(),
+        StandardEffect::LosePoints { .. } => "you lose {points}.".to_string(),
+        StandardEffect::EnemyGainsPoints { .. } => "the opponent gains {points}.".to_string(),
         StandardEffect::Foresee { .. } => "{Foresee}.".to_string(),
         StandardEffect::Kindle { .. } => "{Kindle}.".to_string(),
         StandardEffect::Counterspell { target } => {

--- a/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests.rs
@@ -120,3 +120,27 @@ fn test_round_trip_discard_cards_draw_cards() {
     let serialized = parser_formatter::serialize_ability(&parsed);
     assert_eq!(original, serialized);
 }
+
+#[test]
+fn test_round_trip_dissolve_enemy_you_lose_points() {
+    let original = "{Dissolve} an enemy. You lose {points}.";
+    let parsed = parse_ability(original, "points: 1");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}
+
+#[test]
+fn test_round_trip_dissolve_enemy_opponent_gains_points() {
+    let original = "{Dissolve} an enemy. The opponent gains {points}.";
+    let parsed = parse_ability(original, "points: 1");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}
+
+#[test]
+fn test_round_trip_judgment_draw_cards_opponent_gains_points() {
+    let original = "{Judgment} Draw {cards}. The opponent gains {points}.";
+    let parsed = parse_ability(original, "cards: 2, points: 1");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
@@ -265,3 +265,78 @@ fn test_discard_cards_draw_cards() {
     ))
     "###);
 }
+
+#[test]
+fn test_dissolve_enemy_you_lose_points() {
+    let result = parse_ability("{Dissolve} an enemy. You lose {points}.", "points: 1");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: List([
+        EffectWithOptions(
+          effect: DissolveCharacter(
+            target: Enemy(Character),
+          ),
+          optional: false,
+        ),
+        EffectWithOptions(
+          effect: LosePoints(
+            loses: Points(1),
+          ),
+          optional: false,
+        ),
+      ]),
+    ))
+    "###);
+}
+
+#[test]
+fn test_dissolve_enemy_opponent_gains_points() {
+    let result = parse_ability("{Dissolve} an enemy. The opponent gains {points}.", "points: 1");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: List([
+        EffectWithOptions(
+          effect: DissolveCharacter(
+            target: Enemy(Character),
+          ),
+          optional: false,
+        ),
+        EffectWithOptions(
+          effect: EnemyGainsPoints(
+            count: 1,
+          ),
+          optional: false,
+        ),
+      ]),
+    ))
+    "###);
+}
+
+#[test]
+fn test_judgment_draw_cards_opponent_gains_points() {
+    let result = parse_ability(
+        "{Judgment} Draw {cards}. The opponent gains {points}.",
+        "cards: 2, points: 1",
+    );
+    assert_ron_snapshot!(result, @r###"
+    Triggered(TriggeredAbility(
+      trigger: Keywords([
+        Judgment,
+      ]),
+      effect: List([
+        EffectWithOptions(
+          effect: DrawCards(
+            count: 2,
+          ),
+          optional: false,
+        ),
+        EffectWithOptions(
+          effect: EnemyGainsPoints(
+            count: 1,
+          ),
+          optional: false,
+        ),
+      ]),
+    ))
+    "###);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/parse_error_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/parse_error_tests.rs
@@ -204,3 +204,19 @@ fn test_draw_discard_missing_variables_suggests_fix() {
     assert!(formatted.contains("cards"));
     assert!(formatted.contains("not found"));
 }
+
+#[test]
+fn test_opponent_gains_points_missing_variable_suggests_fix() {
+    let input = "{Dissolve} an enemy. The opponent gains {points}.";
+    let lex_result = lexer_tokenize::lex(input).unwrap();
+    let bindings = VariableBindings::new();
+
+    let result = parser_substitutions::resolve_variables(&lex_result.tokens, &bindings);
+
+    assert!(result.is_err());
+    let error = ParserError::from(result.unwrap_err());
+    let formatted = parser_diagnostics::format_error(&error, input, "test");
+
+    assert!(formatted.contains("points"));
+    assert!(formatted.contains("not found"));
+}

--- a/rules_engine/tests/parser_v2_tests/tests/spanned_ability_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/spanned_ability_tests.rs
@@ -181,3 +181,55 @@ fn test_spanned_discard_cards_draw_cards() {
     assert_eq!(effect.text.trim(), "Discard {discards}. Draw {cards}.");
     assert_valid_span(&effect.span);
 }
+
+#[test]
+fn test_spanned_dissolve_enemy_you_lose_points() {
+    let SpannedAbility::Event(event) =
+        parse_spanned_ability("{Dissolve} an enemy. You lose {points}.", "points: 1")
+    else {
+        panic!("Expected Event ability");
+    };
+
+    assert_eq!(event.additional_cost, None);
+    let SpannedEffect::Effect(effect) = &event.effect else {
+        panic!("Expected Effect, got Modal");
+    };
+    assert_eq!(effect.text.trim(), "{Dissolve} an enemy. You lose {points}.");
+    assert_valid_span(&effect.span);
+}
+
+#[test]
+fn test_spanned_dissolve_enemy_opponent_gains_points() {
+    let SpannedAbility::Event(event) =
+        parse_spanned_ability("{Dissolve} an enemy. The opponent gains {points}.", "points: 1")
+    else {
+        panic!("Expected Event ability");
+    };
+
+    assert_eq!(event.additional_cost, None);
+    let SpannedEffect::Effect(effect) = &event.effect else {
+        panic!("Expected Effect, got Modal");
+    };
+    assert_eq!(effect.text.trim(), "{Dissolve} an enemy. The opponent gains {points}.");
+    assert_valid_span(&effect.span);
+}
+
+#[test]
+fn test_spanned_judgment_draw_cards_opponent_gains_points() {
+    let SpannedAbility::Triggered(triggered) = parse_spanned_ability(
+        "{Judgment} Draw {cards}. The opponent gains {points}.",
+        "cards: 2, points: 1",
+    ) else {
+        panic!("Expected Triggered ability");
+    };
+
+    assert_eq!(triggered.once_per_turn, None);
+    assert_eq!(triggered.trigger.text, "{Judgment}");
+    assert_valid_span(&triggered.trigger.span);
+
+    let SpannedEffect::Effect(effect) = &triggered.effect else {
+        panic!("Expected Effect, got Modal");
+    };
+    assert_eq!(effect.text.trim(), "Draw {cards}. The opponent gains {points}.");
+    assert_valid_span(&effect.span);
+}


### PR DESCRIPTION
Implements parsing for three card abilities:
- "{Dissolve} an enemy. You lose {points}."
- "{Dissolve} an enemy. The opponent gains {points}."
- "{Judgment} Draw {cards}. The opponent gains {points}."

Changes:
- Added resource_effect_parsers.rs with parsers for LosePoints and EnemyGainsPoints
- Updated effect_parser.rs to include resource_effect_parsers
- Added serialization support in parser_formatter.rs
- Added comprehensive test coverage:
  * Parser tests with insta snapshots
  * Round-trip serialization tests
  * Spanned ability tests
  * Error handling tests
- Marked abilities as implemented in rules_text_sorted.json

All tests pass, including full `just review` validation.