### PR TITLE
Add parsing support for dissolve/banish with spark/cost comparison

### DIFF
--- a/rules_engine/docs/rules_text_sorted.json
+++ b/rules_engine/docs/rules_text_sorted.json
@@ -19,9 +19,9 @@
   "{Dissolve} an enemy. The opponent gains {points}.", // Implemented
   "{Judgment} Draw {cards}. The opponent gains {points}.", // Implemented
   "Return an enemy or ally to hand. Draw {cards}.", // Implemented
-  "{Dissolve} an enemy with spark {s} or less.",
-  "{Dissolve} an enemy with spark {s} or more.",
-  "{Banish} an enemy with cost {e} or less.",
+  "{Dissolve} an enemy with spark {s} or less.", // Implemented
+  "{Dissolve} an enemy with spark {s} or more.", // Implemented
+  "{Banish} an enemy with cost {e} or less.", // Implemented
   "{Prevent} a played {fast} card.",
   "{Prevent} a played character.",
   "{Discover} an event.",

--- a/rules_engine/src/parser_v2/src/parser/card_predicate_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/card_predicate_parser.rs
@@ -1,10 +1,13 @@
-use ability_data::predicate::CardPredicate;
+use ability_data::predicate::{CardPredicate, Operator};
 use chumsky::prelude::*;
+use core_data::numerics::{Energy, Spark};
 
-use crate::parser::parser_helpers::{subtype, word, ParserExtra, ParserInput};
+use crate::parser::parser_helpers::{
+    energy, spark, subtype, word, words, ParserExtra, ParserInput,
+};
 
 pub fn parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone {
-    choice((subtype_parser(), card_parser())).boxed()
+    choice((with_spark_parser(), with_cost_parser(), subtype_parser(), card_parser())).boxed()
 }
 
 fn card_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone {
@@ -14,4 +17,38 @@ fn card_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserEx
 fn subtype_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone
 {
     subtype().map(CardPredicate::CharacterType)
+}
+
+fn spark_operator<'a>() -> impl Parser<'a, ParserInput<'a>, Operator<Spark>, ParserExtra<'a>> + Clone
+{
+    choice((
+        words(&["or", "less"]).to(Operator::OrLess),
+        words(&["or", "more"]).to(Operator::OrMore),
+    ))
+}
+
+fn energy_operator<'a>(
+) -> impl Parser<'a, ParserInput<'a>, Operator<Energy>, ParserExtra<'a>> + Clone {
+    choice((
+        words(&["or", "less"]).to(Operator::OrLess),
+        words(&["or", "more"]).to(Operator::OrMore),
+    ))
+}
+
+fn with_spark_parser<'a>(
+) -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone {
+    words(&["with", "spark"]).ignore_then(spark()).then(spark_operator()).map(
+        |(spark_value, operator)| CardPredicate::CharacterWithSpark(Spark(spark_value), operator),
+    )
+}
+
+fn with_cost_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone
+{
+    words(&["with", "cost"]).ignore_then(energy()).then(energy_operator()).map(
+        |(cost_value, operator)| CardPredicate::CardWithCost {
+            target: Box::new(CardPredicate::Character),
+            cost_operator: operator,
+            cost: Energy(cost_value),
+        },
+    )
 }

--- a/rules_engine/src/parser_v2/src/parser/effect/game_effects_parsers.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect/game_effects_parsers.rs
@@ -7,7 +7,8 @@ use crate::parser::parser_helpers::{
 use crate::parser::{card_predicate_parser, predicate_parser};
 
 pub fn parser<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
-    choice((foresee(), discover(), counterspell(), dissolve_character())).boxed()
+    choice((foresee(), discover(), counterspell(), dissolve_character(), banish_character()))
+        .boxed()
 }
 
 pub fn foresee<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
@@ -37,4 +38,13 @@ pub fn dissolve_character<'a>(
         .ignore_then(predicate_parser::predicate_parser())
         .then_ignore(period())
         .map(|target| StandardEffect::DissolveCharacter { target })
+}
+
+pub fn banish_character<'a>(
+) -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
+    directive("banish")
+        .ignore_then(article())
+        .ignore_then(predicate_parser::predicate_parser())
+        .then_ignore(period())
+        .map(|target| StandardEffect::BanishCharacter { target })
 }

--- a/rules_engine/src/parser_v2/src/serializer/parser_formatter.rs
+++ b/rules_engine/src/parser_v2/src/serializer/parser_formatter.rs
@@ -1,6 +1,6 @@
 use ability_data::ability::Ability;
 use ability_data::effect::Effect;
-use ability_data::predicate::{CardPredicate, Predicate};
+use ability_data::predicate::{CardPredicate, Operator, Predicate};
 use ability_data::standard_effect::StandardEffect;
 use ability_data::trigger_event::{TriggerEvent, TriggerKeyword};
 
@@ -45,6 +45,9 @@ pub fn serialize_standard_effect(effect: &StandardEffect) -> String {
         }
         StandardEffect::DissolveCharacter { target } => {
             format!("{{Dissolve}} {}.", serialize_predicate(target))
+        }
+        StandardEffect::BanishCharacter { target } => {
+            format!("{{Banish}} {}.", serialize_predicate(target))
         }
         StandardEffect::Discover { predicate } => {
             format!("{{Discover}} {}.", serialize_card_predicate(predicate))
@@ -152,6 +155,12 @@ fn serialize_your_predicate(card_predicate: &CardPredicate) -> String {
 fn serialize_enemy_predicate(card_predicate: &CardPredicate) -> String {
     match card_predicate {
         CardPredicate::Character => "enemy".to_string(),
+        CardPredicate::CharacterWithSpark(_, operator) => {
+            format!("enemy with spark {{s}} {}", serialize_operator(operator))
+        }
+        CardPredicate::CardWithCost { cost_operator, .. } => {
+            format!("enemy with cost {{e}} {}", serialize_operator(cost_operator))
+        }
         _ => unimplemented!("Serialization not yet implemented for this enemy predicate type"),
     }
 }
@@ -165,5 +174,15 @@ fn serialize_card_predicate(card_predicate: &CardPredicate) -> String {
         _ => {
             unimplemented!("Serialization not yet implemented for this card predicate type")
         }
+    }
+}
+
+fn serialize_operator<T>(operator: &Operator<T>) -> String {
+    match operator {
+        Operator::OrLess => "or less".to_string(),
+        Operator::OrMore => "or more".to_string(),
+        Operator::Exactly => "exactly".to_string(),
+        Operator::LowerBy(_) => "lower".to_string(),
+        Operator::HigherBy(_) => "higher".to_string(),
     }
 }

--- a/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests.rs
@@ -152,3 +152,27 @@ fn test_round_trip_return_enemy_or_ally_to_hand_draw_cards() {
     let serialized = parser_formatter::serialize_ability(&parsed);
     assert_eq!(original, serialized);
 }
+
+#[test]
+fn test_round_trip_dissolve_enemy_with_spark_or_less() {
+    let original = "{Dissolve} an enemy with spark {s} or less.";
+    let parsed = parse_ability(original, "s: 3");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}
+
+#[test]
+fn test_round_trip_dissolve_enemy_with_spark_or_more() {
+    let original = "{Dissolve} an enemy with spark {s} or more.";
+    let parsed = parse_ability(original, "s: 5");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}
+
+#[test]
+fn test_round_trip_banish_enemy_with_cost_or_less() {
+    let original = "{Banish} an enemy with cost {e} or less.";
+    let parsed = parse_ability(original, "e: 2");
+    let serialized = parser_formatter::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
@@ -363,3 +363,43 @@ fn test_return_enemy_or_ally_to_hand_draw_cards() {
     ))
     "###);
 }
+
+#[test]
+fn test_dissolve_enemy_with_spark_or_less() {
+    let result = parse_ability("{Dissolve} an enemy with spark {s} or less.", "s: 3");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(DissolveCharacter(
+        target: Enemy(CharacterWithSpark(Spark(3), OrLess)),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_dissolve_enemy_with_spark_or_more() {
+    let result = parse_ability("{Dissolve} an enemy with spark {s} or more.", "s: 5");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(DissolveCharacter(
+        target: Enemy(CharacterWithSpark(Spark(5), OrMore)),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_banish_enemy_with_cost_or_less() {
+    let result = parse_ability("{Banish} an enemy with cost {e} or less.", "e: 2");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(BanishCharacter(
+        target: Enemy(CardWithCost(
+          target: Character,
+          cost_operator: OrLess,
+          cost: Energy(2),
+        )),
+      )),
+    ))
+    "###);
+}


### PR DESCRIPTION
This commit adds parsing support for the following card abilities:
- "{Dissolve} an enemy with spark {s} or less."
- "{Dissolve} an enemy with spark {s} or more."
- "{Banish} an enemy with cost {e} or less."

Changes:
- Extended card_predicate_parser to parse "with spark {s} or less/or more"
  and "with cost {e} or less/or more" patterns
- Added banish_character parser to game_effects_parsers
- Added serialization support for BanishCharacter effect and new predicates
- Added comprehensive parsing tests and round-trip tests
- Marked implemented entries in rules_text_sorted.json

All tests pass and code follows project style guidelines.