### PR TITLE
Add parsing support for card ability directives

### DIFF
--- a/rules_engine/docs/rules_text_sorted.json
+++ b/rules_engine/docs/rules_text_sorted.json
@@ -22,11 +22,11 @@
   "{Dissolve} an enemy with spark {s} or less.", // Implemented
   "{Dissolve} an enemy with spark {s} or more.", // Implemented
   "{Banish} an enemy with cost {e} or less.", // Implemented
-  "{Prevent} a played {fast} card.",
-  "{Prevent} a played character.",
-  "{Discover} an event.",
-  "{Dissolve} all characters.",
-  "{Materialized} Gain {e}.",
+  "{Prevent} a played {fast} card.", // Implemented
+  "{Prevent} a played character.", // Implemented
+  "{Discover} an event.", // Implemented
+  "{Dissolve} all characters.", // Implemented
+  "{Materialized} Gain {e}.", // Implemented
   "{Judgment} Draw {cards}, then discard {discards}.",
   "{Materialized} Discard {discards}, then draw {cards}.",
   "{MaterializedDissolved} Draw {cards}.",

--- a/rules_engine/src/parser_v2/src/parser/card_predicate_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/card_predicate_parser.rs
@@ -7,11 +7,28 @@ use crate::parser::parser_helpers::{
 };
 
 pub fn parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone {
-    choice((with_spark_parser(), with_cost_parser(), subtype_parser(), card_parser())).boxed()
+    choice((
+        with_spark_parser(),
+        with_cost_parser(),
+        subtype_parser(),
+        character_parser(),
+        event_parser(),
+        card_parser(),
+    ))
+    .boxed()
 }
 
 fn card_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone {
     word("card").to(CardPredicate::Card)
+}
+
+fn character_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone
+{
+    word("character").to(CardPredicate::Character)
+}
+
+fn event_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone {
+    word("event").to(CardPredicate::Event)
 }
 
 fn subtype_parser<'a>() -> impl Parser<'a, ParserInput<'a>, CardPredicate, ParserExtra<'a>> + Clone

--- a/rules_engine/src/parser_v2/src/parser/effect/game_effects_parsers.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect/game_effects_parsers.rs
@@ -26,6 +26,7 @@ pub fn foresee<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserE
 
 pub fn discover<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
     directive("discover")
+        .ignore_then(article().or_not())
         .ignore_then(card_predicate_parser::parser())
         .then_ignore(period())
         .map(|predicate| StandardEffect::Discover { predicate })

--- a/rules_engine/src/parser_v2/src/parser/predicate_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/predicate_parser.rs
@@ -2,11 +2,19 @@ use ability_data::predicate::{CardPredicate, Predicate};
 use chumsky::prelude::*;
 
 use crate::parser::card_predicate_parser;
-use crate::parser::parser_helpers::{word, words, ParserExtra, ParserInput};
+use crate::parser::parser_helpers::{directive, word, words, ParserExtra, ParserInput};
 
 pub fn predicate_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<'a>> + Clone
 {
-    choice((this_parser(), enemy_parser(), any_card_parser())).boxed()
+    choice((
+        this_parser(),
+        enemy_parser(),
+        any_fast_card_parser(),
+        any_character_parser(),
+        any_event_parser(),
+        any_card_parser(),
+    ))
+    .boxed()
 }
 
 fn this_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<'a>> + Clone {
@@ -25,4 +33,20 @@ fn enemy_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra
 
 fn any_card_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<'a>> + Clone {
     word("card").map(|_| Predicate::Any(CardPredicate::Card))
+}
+
+fn any_character_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<'a>> + Clone
+{
+    word("character").map(|_| Predicate::Any(CardPredicate::Character))
+}
+
+fn any_event_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<'a>> + Clone {
+    word("event").map(|_| Predicate::Any(CardPredicate::Event))
+}
+
+fn any_fast_card_parser<'a>() -> impl Parser<'a, ParserInput<'a>, Predicate, ParserExtra<'a>> + Clone
+{
+    directive("fast")
+        .ignore_then(card_predicate_parser::parser())
+        .map(|target| Predicate::Any(CardPredicate::Fast { target: Box::new(target) }))
 }

--- a/rules_engine/src/parser_v2/src/serializer/parser_formatter.rs
+++ b/rules_engine/src/parser_v2/src/serializer/parser_formatter.rs
@@ -46,6 +46,18 @@ pub fn serialize_standard_effect(effect: &StandardEffect) -> String {
         StandardEffect::DissolveCharacter { target } => {
             format!("{{Dissolve}} {}.", serialize_predicate(target))
         }
+        StandardEffect::DissolveCharactersCount { target, count } => {
+            use ability_data::collection_expression::CollectionExpression;
+            match count {
+                CollectionExpression::All => match target {
+                    Predicate::Any(CardPredicate::Character) => {
+                        "{Dissolve} all characters.".to_string()
+                    }
+                    _ => unimplemented!("Unsupported dissolve all characters target"),
+                },
+                _ => unimplemented!("Unsupported dissolve characters count"),
+            }
+        }
         StandardEffect::BanishCharacter { target } => {
             format!("{{Banish}} {}.", serialize_predicate(target))
         }
@@ -171,9 +183,19 @@ fn serialize_card_predicate(card_predicate: &CardPredicate) -> String {
         CardPredicate::Character => "a character".to_string(),
         CardPredicate::Event => "an event".to_string(),
         CardPredicate::CharacterType(_) => "{a-subtype}".to_string(),
+        CardPredicate::Fast { target } => format!("a {{fast}} {}", serialize_fast_target(target)),
         _ => {
             unimplemented!("Serialization not yet implemented for this card predicate type")
         }
+    }
+}
+
+fn serialize_fast_target(card_predicate: &CardPredicate) -> String {
+    match card_predicate {
+        CardPredicate::Card => "card".to_string(),
+        CardPredicate::Character => "character".to_string(),
+        CardPredicate::Event => "event".to_string(),
+        _ => unimplemented!("Unsupported fast target"),
     }
 }
 

--- a/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/effect_parser_tests.rs
@@ -403,3 +403,69 @@ fn test_banish_enemy_with_cost_or_less() {
     ))
     "###);
 }
+
+#[test]
+fn test_prevent_a_played_fast_card() {
+    let result = parse_ability("{Prevent} a played {fast} card.", "");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(Counterspell(
+        target: Any(Fast(
+          target: Card,
+        )),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_prevent_a_played_character() {
+    let result = parse_ability("{Prevent} a played character.", "");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(Counterspell(
+        target: Any(Character),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_discover_an_event() {
+    let result = parse_ability("{Discover} an event.", "");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(Discover(
+        predicate: Event,
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_dissolve_all_characters() {
+    let result = parse_ability("{Dissolve} all characters.", "");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(DissolveCharactersCount(
+        target: Any(Character),
+        count: All,
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_materialized_gain_energy() {
+    let result = parse_ability("{Materialized} Gain {e}.", "e: 2");
+    assert_ron_snapshot!(result, @r###"
+    Triggered(TriggeredAbility(
+      trigger: Keywords([
+        Materialized,
+      ]),
+      effect: Effect(GainEnergy(
+        gains: Energy(2),
+      )),
+    ))
+    "###);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/parse_error_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/parse_error_tests.rs
@@ -236,13 +236,3 @@ fn test_return_enemy_or_ally_to_hand_draw_cards_missing_variable_suggests_fix() 
     assert!(formatted.contains("cards"));
     assert!(formatted.contains("not found"));
 }
-
-#[test]
-fn test_prevent_played_character_parse_succeeds() {
-    let input = "{Prevent} a played character.";
-    let lex_result = lexer_tokenize::lex(input).unwrap();
-    let bindings = VariableBindings::new();
-    let resolved = parser_substitutions::resolve_variables(&lex_result.tokens, &bindings);
-
-    assert!(resolved.is_ok());
-}

--- a/rules_engine/tests/parser_v2_tests/tests/parse_error_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/parse_error_tests.rs
@@ -236,3 +236,13 @@ fn test_return_enemy_or_ally_to_hand_draw_cards_missing_variable_suggests_fix() 
     assert!(formatted.contains("cards"));
     assert!(formatted.contains("not found"));
 }
+
+#[test]
+fn test_prevent_played_character_parse_succeeds() {
+    let input = "{Prevent} a played character.";
+    let lex_result = lexer_tokenize::lex(input).unwrap();
+    let bindings = VariableBindings::new();
+    let resolved = parser_substitutions::resolve_variables(&lex_result.tokens, &bindings);
+
+    assert!(resolved.is_ok());
+}

--- a/rules_engine/tests/parser_v2_tests/tests/spanned_ability_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/spanned_ability_tests.rs
@@ -249,3 +249,18 @@ fn test_spanned_return_enemy_or_ally_to_hand_draw_cards() {
     assert_eq!(effect.text.trim(), "Return an enemy or ally to hand. Draw {cards}.");
     assert_valid_span(&effect.span);
 }
+
+#[test]
+fn test_spanned_dissolve_all_characters() {
+    let SpannedAbility::Event(event) = parse_spanned_ability("{Dissolve} all characters.", "")
+    else {
+        panic!("Expected Event ability");
+    };
+
+    assert_eq!(event.additional_cost, None);
+    let SpannedEffect::Effect(effect) = &event.effect else {
+        panic!("Expected Effect, got Modal");
+    };
+    assert_eq!(effect.text.trim(), "{Dissolve} all characters.");
+    assert_valid_span(&effect.span);
+}


### PR DESCRIPTION
Implement parsing for the following abilities:
- {Prevent} a played {fast} card
- {Prevent} a played character
- {Discover} an event
- {Dissolve} all characters
- {Materialized} Gain {e}

Changes:
- Add CardPredicate parsers for 'character' and 'event' types
- Update counterspell parser to support optional 'played' keyword
- Add dissolve_all_characters parser using DissolveCharactersCount
- Add serialization support for new effects including Fast predicate
- Add tests in spanned_ability_tests.rs and parse_error_tests.rs
- Mark abilities as implemented in rules_text_sorted.json