### PR TITLE
Add parsing support for card abilities

### DIFF
--- a/rules_engine/docs/rules_text_sorted.json
+++ b/rules_engine/docs/rules_text_sorted.json
@@ -143,8 +143,8 @@
 
 
 
-  "{Banish} a card from hand: Play this event for {e}.\n\n{Dissolve} an enemy.",
-  "{Banish} a card from hand: Play this event for {e}.\n\n{Prevent} a played enemy card.",
+  "{Banish} a card from hand: Play this event for {e}.\n\n{Dissolve} an enemy.", // Implemented
+  "{Banish} a card from hand: Play this event for {e}.\n\n{Prevent} a played enemy card.", // Implemented
   "{Banish} an ally. {Materialize} it at end of turn.\n\n{ReclaimForCost}",
   "{Banish} your void with {count} or more cards: {Reclaim} this character.",
   "{ChooseOne}\n{bullet} {e}: Return an enemy to hand.\n{bullet} {e-}: Draw {cards}.",

--- a/rules_engine/src/parser_v2/src/parser/cost_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/cost_parser.rs
@@ -84,3 +84,12 @@ fn banish_from_your_void_cost<'a>(
         .then_ignore(words(&["in", "your", "void"]))
         .map(|_| Cost::BanishCardsFromYourVoid(1))
 }
+
+pub fn banish_from_hand_cost<'a>() -> impl Parser<'a, ParserInput<'a>, Cost, ParserExtra<'a>> + Clone
+{
+    directive("banish")
+        .ignore_then(article())
+        .ignore_then(card_predicate_parser::parser())
+        .then_ignore(words(&["from", "hand"]))
+        .map(|predicate| Cost::BanishFromHand(Predicate::Any(predicate)))
+}

--- a/rules_engine/src/parser_v2/src/parser/static_ability_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/static_ability_parser.rs
@@ -1,9 +1,12 @@
-use ability_data::static_ability::{StandardStaticAbility, StaticAbility};
+use ability_data::static_ability::{AlternateCost, StandardStaticAbility, StaticAbility};
 use chumsky::prelude::*;
 use core_data::numerics::{Energy, Spark};
 
 use crate::parser::card_predicate_parser;
-use crate::parser::parser_helpers::{energy, period, spark, word, words, ParserExtra, ParserInput};
+use crate::parser::cost_parser;
+use crate::parser::parser_helpers::{
+    colon, energy, period, spark, word, words, ParserExtra, ParserInput,
+};
 
 /// Parses static abilities that apply continuously.
 pub fn static_ability_parser<'a>(
@@ -13,8 +16,13 @@ pub fn static_ability_parser<'a>(
 
 fn standard_static_ability<'a>(
 ) -> impl Parser<'a, ParserInput<'a>, StandardStaticAbility, ParserExtra<'a>> + Clone {
-    choice((allied_spark_bonus(), enemy_cards_cost_increase(), your_cards_cost_modification()))
-        .boxed()
+    choice((
+        play_for_alternate_cost(),
+        allied_spark_bonus(),
+        enemy_cards_cost_increase(),
+        your_cards_cost_modification(),
+    ))
+    .boxed()
 }
 
 fn your_cards_cost_modification<'a>(
@@ -73,5 +81,21 @@ fn enemy_cards_cost_increase<'a>(
         .map(|(matching, increase)| StandardStaticAbility::EnemyCardsCostIncrease {
             matching,
             increase: Energy(increase),
+        })
+}
+
+fn play_for_alternate_cost<'a>(
+) -> impl Parser<'a, ParserInput<'a>, StandardStaticAbility, ParserExtra<'a>> + Clone {
+    cost_parser::banish_from_hand_cost()
+        .then_ignore(colon())
+        .then_ignore(words(&["play", "this", "event", "for"]))
+        .then(energy())
+        .then_ignore(period())
+        .map(|(additional_cost, e)| {
+            StandardStaticAbility::PlayForAlternateCost(AlternateCost {
+                energy_cost: Energy(e),
+                additional_cost: Some(additional_cost),
+                if_you_do: None,
+            })
         })
 }

--- a/rules_engine/src/parser_v2/src/serializer/cost_serializer.rs
+++ b/rules_engine/src/parser_v2/src/serializer/cost_serializer.rs
@@ -39,6 +39,9 @@ pub fn serialize_cost(cost: &Cost) -> String {
                 "{Banish} {count} cards in your void".to_string()
             }
         }
+        Cost::BanishFromHand(predicate) => {
+            format!("{{Banish}} {} from hand", serialize_predicate(predicate))
+        }
         _ => unimplemented!("Serialization not yet implemented for this cost type"),
     }
 }

--- a/rules_engine/src/parser_v2/src/serializer/predicate_serializer.rs
+++ b/rules_engine/src/parser_v2/src/serializer/predicate_serializer.rs
@@ -53,6 +53,7 @@ pub fn serialize_your_predicate(card_predicate: &CardPredicate) -> String {
 pub fn serialize_enemy_predicate(card_predicate: &CardPredicate) -> String {
     match card_predicate {
         CardPredicate::Character => "enemy".to_string(),
+        CardPredicate::Card => "enemy card".to_string(),
         CardPredicate::CharacterWithSpark(_, operator) => {
             format!("enemy with spark {{s}} {}", serialize_operator(operator))
         }

--- a/rules_engine/src/parser_v2/src/serializer/static_ability_serializer.rs
+++ b/rules_engine/src/parser_v2/src/serializer/static_ability_serializer.rs
@@ -1,6 +1,8 @@
 use ability_data::static_ability::{StandardStaticAbility, StaticAbility};
 
+use super::cost_serializer::serialize_cost;
 use super::predicate_serializer::serialize_card_predicate_plural;
+use super::serializer_utils::capitalize_first_letter;
 
 pub fn serialize_static_ability(static_ability: &StaticAbility) -> String {
     match static_ability {
@@ -28,6 +30,14 @@ pub fn serialize_standard_static_ability(ability: &StandardStaticAbility) -> Str
         }
         StandardStaticAbility::SparkBonusOtherCharacters { matching, .. } => {
             format!("allied {} have +{{s}} spark.", serialize_card_predicate_plural(matching))
+        }
+        StandardStaticAbility::PlayForAlternateCost(alt_cost) => {
+            let cost = alt_cost
+                .additional_cost
+                .as_ref()
+                .map(|c| capitalize_first_letter(&serialize_cost(c)))
+                .unwrap_or_default();
+            format!("{}: Play this event for {{e}}.", cost)
         }
         _ => unimplemented!("Serialization not yet implemented for this static ability"),
     }

--- a/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests.rs
@@ -1015,3 +1015,19 @@ fn test_round_trip_event_in_void_gains_reclaim_this_turn() {
     let serialized = ability_serializer::serialize_ability(&parsed);
     assert_eq!(original, serialized);
 }
+
+#[test]
+fn test_round_trip_banish_from_hand_play_for_alternate_cost() {
+    let original = "{Banish} a card from hand: Play this event for {e}.";
+    let parsed = parse_ability(original, "e: 0");
+    let serialized = ability_serializer::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}
+
+#[test]
+fn test_round_trip_prevent_a_played_enemy_card() {
+    let original = "{Prevent} a played enemy card.";
+    let parsed = parse_ability(original, "");
+    let serialized = ability_serializer::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/game_effects_parser_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/game_effects_parser_tests.rs
@@ -549,3 +549,15 @@ fn test_discover_fast_subtype_with_spark_general() {
     ))
     "###);
 }
+
+#[test]
+fn test_prevent_a_played_enemy_card() {
+    let result = parse_ability("{Prevent} a played enemy card.", "");
+    assert_ron_snapshot!(result, @r###"
+    Event(EventAbility(
+      effect: Effect(Counterspell(
+        target: Enemy(Card),
+      )),
+    ))
+    "###);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/named_ability_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/named_ability_tests.rs
@@ -124,3 +124,47 @@ fn test_dissolve_enemy_with_cost_reclaim() {
     Named(Reclaim(Some(Energy(2))))
     "###);
 }
+
+#[test]
+fn test_banish_from_hand_alternate_cost_dissolve_enemy() {
+    let result = parse_abilities(
+        "{Banish} a card from hand: Play this event for {e}.\n\n{Dissolve} an enemy.",
+        "e: 0",
+    );
+    assert_eq!(result.len(), 2);
+    assert_ron_snapshot!(result[0], @r###"
+    Static(StaticAbility(PlayForAlternateCost(AlternateCost(
+      energy_cost: Energy(0),
+      additional_cost: Some(BanishFromHand(Any(Card))),
+    ))))
+    "###);
+    assert_ron_snapshot!(result[1], @r###"
+    Event(EventAbility(
+      effect: Effect(DissolveCharacter(
+        target: Enemy(Character),
+      )),
+    ))
+    "###);
+}
+
+#[test]
+fn test_banish_from_hand_alternate_cost_prevent_enemy_card() {
+    let result = parse_abilities(
+        "{Banish} a card from hand: Play this event for {e}.\n\n{Prevent} a played enemy card.",
+        "e: 0",
+    );
+    assert_eq!(result.len(), 2);
+    assert_ron_snapshot!(result[0], @r###"
+    Static(StaticAbility(PlayForAlternateCost(AlternateCost(
+      energy_cost: Energy(0),
+      additional_cost: Some(BanishFromHand(Any(Card))),
+    ))))
+    "###);
+    assert_ron_snapshot!(result[1], @r###"
+    Event(EventAbility(
+      effect: Effect(Counterspell(
+        target: Enemy(Card),
+      )),
+    ))
+    "###);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/spanned_ability_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/spanned_ability_tests.rs
@@ -1600,3 +1600,69 @@ fn test_spanned_materialized_banish_any_number_of_allies_then_materialize_them()
     assert_eq!(effect.text.trim(), "{Banish} any number of allies, then {materialize} them.");
     assert_valid_span(&effect.span);
 }
+
+#[test]
+fn test_spanned_banish_from_hand_play_for_alternate_cost() {
+    let SpannedAbility::Static { text } =
+        parse_spanned_ability("{Banish} a card from hand: Play this event for {e}.", "e: 0")
+    else {
+        panic!("Expected Static ability");
+    };
+
+    assert_eq!(text.text, "{Banish} a card from hand: Play this event for {e}.");
+    assert_valid_span(&text.span);
+}
+
+#[test]
+fn test_spanned_banish_from_hand_alternate_cost_dissolve_enemy() {
+    let abilities = parse_spanned_abilities(
+        "{Banish} a card from hand: Play this event for {e}.\n\n{Dissolve} an enemy.",
+        "e: 0",
+    );
+    assert_eq!(abilities.len(), 2);
+
+    let SpannedAbility::Static { text } = &abilities[0] else {
+        panic!("Expected Static ability");
+    };
+
+    assert_eq!(text.text, "{Banish} a card from hand: Play this event for {e}.");
+    assert_valid_span(&text.span);
+
+    let SpannedAbility::Event(event) = &abilities[1] else {
+        panic!("Expected Event ability");
+    };
+
+    let SpannedEffect::Effect(effect) = &event.effect else {
+        panic!("Expected Effect");
+    };
+
+    assert_eq!(effect.text.trim(), "{Dissolve} an enemy.");
+    assert_valid_span(&effect.span);
+}
+
+#[test]
+fn test_spanned_banish_from_hand_alternate_cost_prevent_enemy_card() {
+    let abilities = parse_spanned_abilities(
+        "{Banish} a card from hand: Play this event for {e}.\n\n{Prevent} a played enemy card.",
+        "e: 0",
+    );
+    assert_eq!(abilities.len(), 2);
+
+    let SpannedAbility::Static { text } = &abilities[0] else {
+        panic!("Expected Static ability");
+    };
+
+    assert_eq!(text.text, "{Banish} a card from hand: Play this event for {e}.");
+    assert_valid_span(&text.span);
+
+    let SpannedAbility::Event(event) = &abilities[1] else {
+        panic!("Expected Event ability");
+    };
+
+    let SpannedEffect::Effect(effect) = &event.effect else {
+        panic!("Expected Effect");
+    };
+
+    assert_eq!(effect.text.trim(), "{Prevent} a played enemy card.");
+    assert_valid_span(&effect.span);
+}

--- a/rules_engine/tests/parser_v2_tests/tests/static_ability_parser_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/static_ability_parser_tests.rs
@@ -45,3 +45,14 @@ fn test_allied_plural_subtype_have_spark() {
     )))
     "###);
 }
+
+#[test]
+fn test_banish_from_hand_play_for_alternate_cost() {
+    let result = parse_ability("{Banish} a card from hand: Play this event for {e}.", "e: 0");
+    assert_ron_snapshot!(result, @r###"
+    Static(StaticAbility(PlayForAlternateCost(AlternateCost(
+      energy_cost: Energy(0),
+      additional_cost: Some(BanishFromHand(Any(Card))),
+    ))))
+    "###);
+}


### PR DESCRIPTION
Implements parsing for cards with the pattern:
- "{Banish} a card from hand: Play this event for {e}."

This adds:
- Cost::BanishFromHand parser in cost_parser.rs
- PlayForAlternateCost static ability parser in static_ability_parser.rs
- Serialization support for round-trip testing
- Enemy card predicate serialization (for "enemy card")
- Comprehensive tests for parsing, serialization, and spanned abilities