### PR TITLE
Fix parser segfaults in low-memory Docker environments

### DIFF
--- a/justfile
+++ b/justfile
@@ -76,7 +76,10 @@ watch-release:
 
 test:
     #!/usr/bin/env bash
-    output=$(cargo test --manifest-path rules_engine/Cargo.toml 2>&1)
+    # Set RUST_MIN_STACK for parser_v2 tests which need extra stack space for
+    # deep Chumsky parser hierarchies. Limit test parallelism to prevent memory
+    # exhaustion in low-memory environments (like Docker).
+    output=$(RUST_MIN_STACK=8388608 cargo test --manifest-path rules_engine/Cargo.toml -- --test-threads=4 2>&1)
     if [ $? -eq 0 ]; then
         echo "Tests passed"
     else
@@ -85,13 +88,13 @@ test:
     fi
 
 test-verbose:
-    cargo test --manifest-path rules_engine/Cargo.toml
+    RUST_MIN_STACK=8388608 cargo test --manifest-path rules_engine/Cargo.toml -- --test-threads=4
 
 battle-test *args='':
     cargo test --manifest-path rules_engine/Cargo.toml -p battle_tests "$@"
 
 parser-test *args='':
-    cargo test --manifest-path rules_engine/Cargo.toml -p parser_v2_tests "$@"
+    RUST_MIN_STACK=8388608 cargo test --manifest-path rules_engine/Cargo.toml -p parser_v2_tests -- --test-threads=4 "$@"
 
 doc:
     cargo doc --manifest-path rules_engine/Cargo.toml

--- a/rules_engine/.cargo/config.toml
+++ b/rules_engine/.cargo/config.toml
@@ -1,0 +1,19 @@
+# Cargo configuration for the rules engine
+#
+# This configuration helps ensure tests run reliably in low-memory environments
+# (like Docker containers) by addressing stack overflow issues caused by
+# the deep Chumsky parser hierarchy.
+#
+# The parser_v2 tests require:
+# 1. Sufficient stack space per thread (at least 8MB for parser construction)
+# 2. Limited parallelism to prevent total memory exhaustion
+#
+# To run parser tests in constrained environments, use:
+#   RUST_MIN_STACK=8388608 cargo test -p parser_v2_tests -- --test-threads=4
+#
+# Or for maximum safety in very low-memory environments:
+#   cargo test -p parser_v2_tests -- --test-threads=1
+
+[alias]
+# Alias for running parser tests with proper stack configuration
+parser-test-safe = "test -p parser_v2_tests -- --test-threads=4"

--- a/rules_engine/Cargo.lock
+++ b/rules_engine/Cargo.lock
@@ -2635,6 +2635,7 @@ dependencies = [
  "parser_v2",
  "parser_v2_benchmarks",
  "regex",
+ "stacker",
 ]
 
 [[package]]

--- a/rules_engine/tests/parser_v2_tests/Cargo.toml
+++ b/rules_engine/tests/parser_v2_tests/Cargo.toml
@@ -16,3 +16,4 @@ core_data = { path = "../../src/core_data" }
 chumsky = { workspace = true }
 insta = { workspace = true }
 regex = { workspace = true }
+stacker = "0.1"

--- a/rules_engine/tests/parser_v2_tests/src/test_helpers.rs
+++ b/rules_engine/tests/parser_v2_tests/src/test_helpers.rs
@@ -8,56 +8,83 @@ use parser_v2::parser::ability_parser;
 use parser_v2::variables::parser_bindings::VariableBindings;
 use parser_v2::variables::parser_substitutions;
 
-pub fn parse_ability(input: &str, vars: &str) -> Ability {
-    let lex_result = lexer_tokenize::lex(input).unwrap();
-    let bindings = VariableBindings::parse(vars).unwrap();
-    let resolved = parser_substitutions::resolve_variables(&lex_result.tokens, &bindings).unwrap();
-    let parser = ability_parser::ability_parser();
-    parser.parse(&resolved).into_result().unwrap()
+/// Stack red zone size - if less than this remains, grow the stack.
+/// The parser hierarchy is deep and needs significant stack during construction.
+/// We use a very large red zone to ensure we catch the overflow early, before
+/// the thread's stack is exhausted.
+const STACK_RED_ZONE: usize = 1024 * 1024; // 1 MB
+
+/// Stack size to grow by when needed.
+const STACK_SIZE: usize = 4 * 1024 * 1024; // 4 MB
+
+/// Wrapper that ensures sufficient stack space for parser operations.
+/// The deep Chumsky parser hierarchy requires significant stack during
+/// construction, which can cause stack overflow in low-memory environments
+/// (like Docker) when tests run in parallel.
+fn with_stack<T>(f: impl FnOnce() -> T) -> T {
+    stacker::maybe_grow(STACK_RED_ZONE, STACK_SIZE, f)
 }
 
-pub fn parse_abilities(input: &str, vars: &str) -> Vec<Ability> {
-    let bindings = VariableBindings::parse(vars).unwrap();
-    let mut abilities = Vec::new();
-    for block in input.split("\n\n") {
-        let block = block.trim();
-        if block.is_empty() {
-            continue;
-        }
-        let lex_result = lexer_tokenize::lex(block).unwrap();
+pub fn parse_ability(input: &str, vars: &str) -> Ability {
+    with_stack(|| {
+        let lex_result = lexer_tokenize::lex(input).unwrap();
+        let bindings = VariableBindings::parse(vars).unwrap();
         let resolved =
             parser_substitutions::resolve_variables(&lex_result.tokens, &bindings).unwrap();
         let parser = ability_parser::ability_parser();
-        abilities.push(parser.parse(&resolved).into_result().unwrap());
-    }
-    abilities
+        parser.parse(&resolved).into_result().unwrap()
+    })
+}
+
+pub fn parse_abilities(input: &str, vars: &str) -> Vec<Ability> {
+    with_stack(|| {
+        let bindings = VariableBindings::parse(vars).unwrap();
+        let mut abilities = Vec::new();
+        for block in input.split("\n\n") {
+            let block = block.trim();
+            if block.is_empty() {
+                continue;
+            }
+            let lex_result = lexer_tokenize::lex(block).unwrap();
+            let resolved =
+                parser_substitutions::resolve_variables(&lex_result.tokens, &bindings).unwrap();
+            let parser = ability_parser::ability_parser();
+            abilities.push(parser.parse(&resolved).into_result().unwrap());
+        }
+        abilities
+    })
 }
 
 pub fn parse_spanned_ability(input: &str, vars: &str) -> SpannedAbility {
-    let lex_result = lexer_tokenize::lex(input).unwrap();
-    let bindings = VariableBindings::parse(vars).unwrap();
-    let resolved = parser_substitutions::resolve_variables(&lex_result.tokens, &bindings).unwrap();
-    let parser = ability_parser::ability_parser();
-    let ability = parser.parse(&resolved).into_result().unwrap();
-    parser_builder::build_spanned_ability(&ability, &lex_result).unwrap()
-}
-
-pub fn parse_spanned_abilities(input: &str, vars: &str) -> Vec<SpannedAbility> {
-    let bindings = VariableBindings::parse(vars).unwrap();
-    let mut abilities = Vec::new();
-    for block in input.split("\n\n") {
-        let block = block.trim();
-        if block.is_empty() {
-            continue;
-        }
-        let lex_result = lexer_tokenize::lex(block).unwrap();
+    with_stack(|| {
+        let lex_result = lexer_tokenize::lex(input).unwrap();
+        let bindings = VariableBindings::parse(vars).unwrap();
         let resolved =
             parser_substitutions::resolve_variables(&lex_result.tokens, &bindings).unwrap();
         let parser = ability_parser::ability_parser();
         let ability = parser.parse(&resolved).into_result().unwrap();
-        abilities.push(parser_builder::build_spanned_ability(&ability, &lex_result).unwrap());
-    }
-    abilities
+        parser_builder::build_spanned_ability(&ability, &lex_result).unwrap()
+    })
+}
+
+pub fn parse_spanned_abilities(input: &str, vars: &str) -> Vec<SpannedAbility> {
+    with_stack(|| {
+        let bindings = VariableBindings::parse(vars).unwrap();
+        let mut abilities = Vec::new();
+        for block in input.split("\n\n") {
+            let block = block.trim();
+            if block.is_empty() {
+                continue;
+            }
+            let lex_result = lexer_tokenize::lex(block).unwrap();
+            let resolved =
+                parser_substitutions::resolve_variables(&lex_result.tokens, &bindings).unwrap();
+            let parser = ability_parser::ability_parser();
+            let ability = parser.parse(&resolved).into_result().unwrap();
+            abilities.push(parser_builder::build_spanned_ability(&ability, &lex_result).unwrap());
+        }
+        abilities
+    })
 }
 
 pub fn build_spanned_ability(ability: &Ability, input: &str) -> SpannedAbility {


### PR DESCRIPTION
The deep Chumsky parser hierarchy requires significant stack space during
parser construction. In low-memory environments (like Docker containers),
running tests in parallel would cause stack overflow and segfaults.

Changes:
- Add stacker dependency to parser_v2_tests for stack growth during parsing
- Wrap parser helper functions with stacker::maybe_grow to ensure sufficient
  stack space (1MB red zone, 4MB growth)
- Update justfile test commands to set RUST_MIN_STACK=8388608 and limit test
  parallelism to 4 threads
- Add .cargo/config.toml with documentation and a parser-test-safe alias

This allows tests to pass reliably in constrained environments while
maintaining reasonable parallelism for performance.