### PR TITLE
Fix objc2 error on non-macOS platforms

### DIFF
--- a/rules_engine/src/llmc/Cargo.toml
+++ b/rules_engine/src/llmc/Cargo.toml
@@ -17,6 +17,8 @@ anyhow = { workspace = true }
 atomic-write-file = { workspace = true }
 clap = { workspace = true }
 fastrand = { workspace = true }
-mac-notification-sys = "0.6"
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+mac-notification-sys = "0.6"

--- a/rules_engine/src/llmc/src/notify.rs
+++ b/rules_engine/src/llmc/src/notify.rs
@@ -1,7 +1,10 @@
-use anyhow::{Context, Result};
+#[cfg(target_os = "macos")]
+use anyhow::Context;
+use anyhow::Result;
+#[cfg(target_os = "macos")]
 use mac_notification_sys::{send_notification as send_mac_notification, set_application};
 
-/// Send a macOS notification.
+#[cfg(target_os = "macos")]
 pub fn send_notification(title: &str, message: &str) -> Result<()> {
     let bundle = mac_notification_sys::get_bundle_identifier_or_default("com.apple.Terminal");
     set_application(&bundle).with_context(|| "Failed to set application bundle")?;
@@ -9,5 +12,11 @@ pub fn send_notification(title: &str, message: &str) -> Result<()> {
     send_mac_notification(title, None, message, None)
         .with_context(|| format!("Failed to send notification: {title} - {message}"))?;
 
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn send_notification(_title: &str, _message: &str) -> Result<()> {
+    // Notifications are only supported on macOS
     Ok(())
 }

--- a/rules_engine/src/parser_v2/src/parser/cost_parser.rs
+++ b/rules_engine/src/parser_v2/src/parser/cost_parser.rs
@@ -99,7 +99,7 @@ fn banish_void_with_min_count_cost<'a>(
         .ignore_then(words(&["your", "void", "with"]))
         .ignore_then(count())
         .then_ignore(words(&["or", "more", "cards"]))
-        .map(|min_count| Cost::BanishAllCardsFromYourVoidWithMinCount(min_count))
+        .map(Cost::BanishAllCardsFromYourVoidWithMinCount)
 }
 
 fn banish_from_your_void_cost<'a>(


### PR DESCRIPTION
- Make mac-notification-sys a macOS-only dependency in llmc/Cargo.toml
- Add conditional compilation for notify module to provide no-op implementation on non-macOS
- Fix clippy warning: redundant closure in cost_parser.rs

This resolves the build error where objc2 was being pulled in on Linux environments, causing `just check` and `just review` to fail with "objc2 only works on Apple platforms" error.