### PR TITLE
Add pay cost to effect parsing

### DIFF
--- a/rules_engine/docs/rules_text_sorted.json
+++ b/rules_engine/docs/rules_text_sorted.json
@@ -1,5 +1,4 @@
 [
-  "{Judgment} Pay {e} to {kindle} and {banish} {cards} from the opponent's void.",
   "{Judgment} You may {banish} {cards} from your void to {dissolve} an enemy with cost {e} or less.",
   "{Judgment} You may {banish} a card from the enemy's void to gain {e}.",
   "{Judgment} You may abandon {a-subtype} to {discover} {a-subtype} with cost {e} higher and {materialize} it.",

--- a/rules_engine/src/parser_v2/src/parser/effect/game_effects_parsers.rs
+++ b/rules_engine/src/parser_v2/src/parser/effect/game_effects_parsers.rs
@@ -5,8 +5,8 @@ use ability_data::standard_effect::StandardEffect;
 use chumsky::prelude::*;
 
 use crate::parser::parser_helpers::{
-    article, directive, foresee_count, it_or_them_count, up_to_n_allies, word, words, ParserExtra,
-    ParserInput,
+    article, cards, directive, foresee_count, it_or_them_count, up_to_n_allies, word, words,
+    ParserExtra, ParserInput,
 };
 use crate::parser::{card_predicate_parser, cost_parser, predicate_parser};
 
@@ -16,6 +16,7 @@ pub fn parser<'a>() -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserEx
         choice((
             choice((dissolve_all_characters(), dissolve_character())).boxed(),
             choice((
+                banish_cards_from_opponent_void(),
                 banish_up_to_n(),
                 banish_collection(),
                 banish_character(),
@@ -109,6 +110,14 @@ pub fn banish_up_to_n<'a>(
             count: CollectionExpression::UpTo(count),
         }
     })
+}
+
+pub fn banish_cards_from_opponent_void<'a>(
+) -> impl Parser<'a, ParserInput<'a>, StandardEffect, ParserExtra<'a>> + Clone {
+    directive("banish")
+        .ignore_then(cards())
+        .then_ignore(words(&["from", "the", "opponent's", "void"]))
+        .map(|count| StandardEffect::BanishCardsFromEnemyVoid { count })
 }
 
 pub fn banish_enemy_void<'a>(

--- a/rules_engine/src/parser_v2/src/serializer/effect_serializer.rs
+++ b/rules_engine/src/parser_v2/src/serializer/effect_serializer.rs
@@ -139,6 +139,9 @@ pub fn serialize_standard_effect(effect: &StandardEffect) -> String {
             }
             _ => unimplemented!("Serialization not yet implemented for this banish collection"),
         },
+        StandardEffect::BanishCardsFromEnemyVoid { .. } => {
+            "{Banish} {cards} from the opponent's void.".to_string()
+        }
         StandardEffect::BanishEnemyVoid => "{Banish} the opponent's void.".to_string(),
         StandardEffect::Discover { predicate } => {
             format!("{{Discover}} {}.", serialize_card_predicate(predicate))
@@ -224,6 +227,23 @@ pub fn serialize_effect(effect: &Effect) -> String {
                     }
                 }
                 result.push_str("you may ");
+                if let Some(trigger_cost) = &effects[0].trigger_cost {
+                    result.push_str(&format!("{} to ", serialize_trigger_cost(trigger_cost)));
+                }
+                result.push_str(&format!("{}.", effect_strings.join(" and ")));
+                result
+            } else if !all_optional && all_have_trigger_cost && !effects.is_empty() {
+                let effect_strings: Vec<String> = effects
+                    .iter()
+                    .map(|e| serialize_standard_effect(&e.effect).trim_end_matches('.').to_string())
+                    .collect();
+                let mut result = String::new();
+                if has_condition {
+                    if let Some(condition) = &effects[0].condition {
+                        result.push_str(&serialize_condition(condition));
+                        result.push(' ');
+                    }
+                }
                 if let Some(trigger_cost) = &effects[0].trigger_cost {
                     result.push_str(&format!("{} to ", serialize_trigger_cost(trigger_cost)));
                 }

--- a/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests/judgment_abilities.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/ability_round_trip_tests/judgment_abilities.rs
@@ -99,6 +99,14 @@ fn test_round_trip_materialized_return_ally_to_hand() {
 }
 
 #[test]
+fn test_round_trip_judgment_pay_energy_to_kindle_and_banish_cards_from_opponent_void() {
+    let original = "{Judgment} Pay {e} to {Kindle} and {Banish} {cards} from the opponent's void.";
+    let parsed = parse_ability(original, "e: 1, k: 1, cards: 2");
+    let serialized = ability_serializer::serialize_ability(&parsed);
+    assert_eq!(original, serialized);
+}
+
+#[test]
 fn test_round_trip_materialized_you_may_return_ally_to_hand() {
     let original = "{Materialized} You may return an ally to hand.";
     let parsed = parse_ability(original, "");

--- a/rules_engine/tests/parser_v2_tests/tests/game_effects_parser_tests.rs
+++ b/rules_engine/tests/parser_v2_tests/tests/game_effects_parser_tests.rs
@@ -628,3 +628,34 @@ fn test_dissolve_enemy_with_cost_less_than_void_count() {
     ))
     "###);
 }
+
+#[test]
+fn test_judgment_pay_energy_to_kindle_and_banish_cards_from_opponent_void() {
+    let result = parse_ability(
+        "{Judgment} Pay {e} to {kindle} and {banish} {cards} from the opponent's void.",
+        "e: 1, k: 1, cards: 2",
+    );
+    assert_ron_snapshot!(result, @r###"
+    Triggered(TriggeredAbility(
+      trigger: Keywords([
+        Judgment,
+      ]),
+      effect: List([
+        EffectWithOptions(
+          effect: Kindle(
+            amount: Spark(1),
+          ),
+          optional: false,
+          trigger_cost: Some(Energy(Energy(1))),
+        ),
+        EffectWithOptions(
+          effect: BanishCardsFromEnemyVoid(
+            count: 2,
+          ),
+          optional: false,
+          trigger_cost: Some(Energy(Energy(1))),
+        ),
+      ]),
+    ))
+    "###);
+}


### PR DESCRIPTION
Add support for parsing abilities with "pay {e} to" cost prefix,
and implement banish cards from opponent's void effect parser.