### PR TITLE
Add Go prototypes directory and integrate Go checks into review tooling

### DIFF
--- a/justfile
+++ b/justfile
@@ -19,9 +19,9 @@ review *args:
         python3 scripts/review/review_runner.py {{args}}
     fi
 
-review-direct: check-snapshots check-format check-python-format check-docs-format check-token-limits build clippy style-validator rlf-lint review-core-test python-test pyre-check local-unity-test parser-test tv-check tv-clippy tv-test cqs-check
+review-direct: check-snapshots check-format check-python-format check-docs-format check-token-limits build clippy style-validator rlf-lint review-core-test python-test pyre-check local-unity-test parser-test tv-check tv-clippy tv-test cqs-check go-prototypes-check-format go-prototypes-typecheck go-prototypes-lint go-prototypes-test
 
-review-verbose: check-snapshots check-format-verbose check-python-format-verbose check-docs-format-verbose check-token-limits-verbose build-verbose clippy-verbose style-validator-verbose rlf-lint-verbose local-unity-test review-core-test-verbose python-test-verbose pyre-check-verbose parser-test tv-check-verbose tv-clippy-verbose tv-test cqs-check
+review-verbose: check-snapshots check-format-verbose check-python-format-verbose check-docs-format-verbose check-token-limits-verbose build-verbose clippy-verbose style-validator-verbose rlf-lint-verbose local-unity-test review-core-test-verbose python-test-verbose pyre-check-verbose parser-test tv-check-verbose tv-clippy-verbose tv-test cqs-check go-prototypes-check-format-verbose go-prototypes-typecheck-verbose go-prototypes-lint-verbose go-prototypes-test-verbose
 
 review-scope-plan:
     python3 scripts/review/review_scope.py plan
@@ -540,7 +540,7 @@ insta:
 
 # Reformats code. Requires nightly because several useful options (e.g. imports_granularity) are
 # nightly-only
-fmt: style-validator-fix rlf-fmt fmt-docs fmt-csharp fmt-python
+fmt: style-validator-fix rlf-fmt fmt-docs fmt-csharp fmt-python fmt-go-prototypes
     #!/usr/bin/env bash
     python3 scripts/llms/llm_symlinks.py > /dev/null
     output=$(cd rules_engine && cargo +nightly fmt 2>&1)
@@ -606,6 +606,149 @@ check-format:
 check-format-verbose:
     cd rules_engine && cargo +nightly fmt -- --check
 
+
+fmt-go-prototypes:
+    #!/usr/bin/env bash
+    if [ ! -d prototypes ]; then
+        echo "No prototypes directory found, skipping Go formatting"
+        exit 0
+    fi
+    if [ ! -f prototypes/go.work ]; then
+        echo "No prototypes/go.work found, skipping Go formatting"
+        exit 0
+    fi
+
+    files=$(find prototypes -name '*.go' -type f)
+    if [ -z "$files" ]; then
+        echo "No Go files found"
+        exit 0
+    fi
+
+    gofmt -w $files
+    echo "Go prototypes formatted"
+
+check-go-prototypes-dir:
+    #!/usr/bin/env bash
+    if [ ! -d prototypes ]; then
+        echo "No prototypes directory found, skipping Go checks"
+        exit 0
+    fi
+
+go-prototypes-check-format: check-go-prototypes-dir
+    #!/usr/bin/env bash
+    files=$(find prototypes -name '*.go' -type f)
+    if [ -z "$files" ]; then
+        echo "No Go files found"
+        exit 0
+    fi
+
+    output=$(gofmt -l $files)
+    if [ -z "$output" ]; then
+        echo "Go prototypes format OK"
+    else
+        echo "$output"
+        exit 1
+    fi
+
+go-prototypes-check-format-verbose: check-go-prototypes-dir
+    #!/usr/bin/env bash
+    files=$(find prototypes -name '*.go' -type f)
+    if [ -n "$files" ]; then
+        gofmt -l $files
+    fi
+
+go-prototypes-typecheck: check-go-prototypes-dir
+    #!/usr/bin/env bash
+    modules=$(find prototypes -name 'go.mod' -type f)
+    if [ -z "$modules" ]; then
+        echo "No Go modules found"
+        exit 0
+    fi
+
+    for mod in $modules; do
+        module_dir=$(dirname "$mod")
+        output=$(cd "$module_dir" && go build ./... 2>&1)
+        if [ $? -ne 0 ]; then
+            echo "$output"
+            exit 1
+        fi
+    done
+    echo "Go prototypes typecheck passed"
+
+go-prototypes-typecheck-verbose: check-go-prototypes-dir
+    #!/usr/bin/env bash
+    modules=$(find prototypes -name 'go.mod' -type f)
+    if [ -z "$modules" ]; then
+        echo "No Go modules found"
+        exit 0
+    fi
+
+    for mod in $modules; do
+        module_dir=$(dirname "$mod")
+        (cd "$module_dir" && go build ./...)
+    done
+
+go-prototypes-lint: check-go-prototypes-dir
+    #!/usr/bin/env bash
+    modules=$(find prototypes -name 'go.mod' -type f)
+    if [ -z "$modules" ]; then
+        echo "No Go modules found"
+        exit 0
+    fi
+
+    for mod in $modules; do
+        module_dir=$(dirname "$mod")
+        output=$(cd "$module_dir" && go vet ./... 2>&1)
+        if [ $? -ne 0 ]; then
+            echo "$output"
+            exit 1
+        fi
+    done
+    echo "Go prototypes lint passed"
+
+go-prototypes-lint-verbose: check-go-prototypes-dir
+    #!/usr/bin/env bash
+    modules=$(find prototypes -name 'go.mod' -type f)
+    if [ -z "$modules" ]; then
+        echo "No Go modules found"
+        exit 0
+    fi
+
+    for mod in $modules; do
+        module_dir=$(dirname "$mod")
+        (cd "$module_dir" && go vet ./...)
+    done
+
+go-prototypes-test: check-go-prototypes-dir
+    #!/usr/bin/env bash
+    modules=$(find prototypes -name 'go.mod' -type f)
+    if [ -z "$modules" ]; then
+        echo "No Go modules found"
+        exit 0
+    fi
+
+    for mod in $modules; do
+        module_dir=$(dirname "$mod")
+        output=$(cd "$module_dir" && go test ./... 2>&1)
+        if [ $? -ne 0 ]; then
+            echo "$output"
+            exit 1
+        fi
+    done
+    echo "Go prototypes tests passed"
+
+go-prototypes-test-verbose: check-go-prototypes-dir
+    #!/usr/bin/env bash
+    modules=$(find prototypes -name 'go.mod' -type f)
+    if [ -z "$modules" ]; then
+        echo "No Go modules found"
+        exit 0
+    fi
+
+    for mod in $modules; do
+        module_dir=$(dirname "$mod")
+        (cd "$module_dir" && go test ./...)
+    done
 fmt-python:
     #!/usr/bin/env bash
     output=$(uvx black scripts/ --exclude '\.venv' 2>&1)

--- a/prototypes/README.md
+++ b/prototypes/README.md
@@ -1,0 +1,19 @@
+# Prototypes
+
+This directory contains standalone Go prototypes.
+
+## Layout
+
+Each prototype should live in its own subdirectory with its own `go.mod`.
+The `go.work` file in this directory tracks all active prototypes so tooling can
+run across every module at once.
+
+## Current prototype
+
+- `hello_world/`: basic binary used as a starter template.
+
+## Adding a new prototype
+
+1. Create a new subdirectory, e.g. `prototypes/my_proto`.
+2. Run `go mod init dreamtides/prototypes/my_proto` inside it.
+3. Add the module path to `prototypes/go.work` under `use (...)`.

--- a/prototypes/go.work
+++ b/prototypes/go.work
@@ -1,0 +1,5 @@
+go 1.22
+
+use (
+	./hello_world
+)

--- a/prototypes/hello_world/go.mod
+++ b/prototypes/hello_world/go.mod
@@ -1,0 +1,3 @@
+module dreamtides/prototypes/hello_world
+
+go 1.22

--- a/prototypes/hello_world/main.go
+++ b/prototypes/hello_world/main.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(message())
+}
+
+func message() string {
+	return "Hello from Dreamtides prototypes!"
+}

--- a/prototypes/hello_world/main_test.go
+++ b/prototypes/hello_world/main_test.go
@@ -1,0 +1,9 @@
+package main
+
+import "testing"
+
+func TestMessage(t *testing.T) {
+	if got, want := message(), "Hello from Dreamtides prototypes!"; got != want {
+		t.Fatalf("message() = %q, want %q", got, want)
+	}
+}

--- a/scripts/review/review_runner.py
+++ b/scripts/review/review_runner.py
@@ -273,6 +273,42 @@ def step_specs() -> list[StepSpec]:
                 ),
             ],
         ),
+        StepSpec(
+            "go-prototypes-check-format",
+            [
+                CommandSpec(
+                    "go-prototypes-check-format",
+                    ["just", "go-prototypes-check-format"],
+                )
+            ],
+        ),
+        StepSpec(
+            "go-prototypes-typecheck",
+            [
+                CommandSpec(
+                    "go-prototypes-typecheck",
+                    ["just", "go-prototypes-typecheck"],
+                )
+            ],
+        ),
+        StepSpec(
+            "go-prototypes-lint",
+            [
+                CommandSpec(
+                    "go-prototypes-lint",
+                    ["just", "go-prototypes-lint"],
+                )
+            ],
+        ),
+        StepSpec(
+            "go-prototypes-test",
+            [
+                CommandSpec(
+                    "go-prototypes-test",
+                    ["just", "go-prototypes-test"],
+                )
+            ],
+        ),
     ]
 
 

--- a/scripts/review/review_scope.py
+++ b/scripts/review/review_scope.py
@@ -21,6 +21,7 @@ DEFAULT_LOCAL_SCOPE_STRATEGY = "head-if-dirty"
 MARKDOWN_EXTENSIONS = (".md", ".mdx", ".markdown")
 PYTHON_EXTENSIONS = (".py",)
 SHELL_EXTENSIONS = (".sh",)
+GO_EXTENSIONS = (".go",)
 
 CommandRunner = Callable[[list[str], Path], tuple[int, str, str]]
 
@@ -41,6 +42,8 @@ class ScopeConfig:
     tv_path_prefixes: tuple[str, ...]
     csharp_crate_seeds: tuple[str, ...]
     csharp_path_prefixes: tuple[str, ...]
+    go_crate_seeds: tuple[str, ...]
+    go_path_prefixes: tuple[str, ...]
     cqs_crate_seeds: tuple[str, ...]
     cqs_path_prefixes: tuple[str, ...]
     core_path_prefixes: tuple[str, ...]
@@ -51,6 +54,7 @@ class ScopeConfig:
     tv_steps: tuple[str, ...]
     python_steps: tuple[str, ...]
     csharp_steps: tuple[str, ...]
+    go_steps: tuple[str, ...]
     cqs_steps: tuple[str, ...]
 
 
@@ -338,6 +342,7 @@ def load_scope_config(config_path: Path | None = None) -> ScopeConfig:
     parser_section = payload.get("parser", {})
     tv_section = payload.get("tv", {})
     csharp_section = payload.get("csharp", {})
+    go_section = payload.get("go", {})
     cqs_section = payload.get("constructed_quest_prototype", {})
 
     if not isinstance(parser_section, dict):
@@ -346,6 +351,8 @@ def load_scope_config(config_path: Path | None = None) -> ScopeConfig:
         raise ScopePlannerError("scope config 'tv' must be an object")
     if not isinstance(csharp_section, dict):
         raise ScopePlannerError("scope config 'csharp' must be an object")
+    if not isinstance(go_section, dict):
+        raise ScopePlannerError("scope config 'go' must be an object")
     if not isinstance(cqs_section, dict):
         raise ScopePlannerError(
             "scope config 'constructed_quest_prototype' must be an object"
@@ -395,6 +402,10 @@ def load_scope_config(config_path: Path | None = None) -> ScopeConfig:
         csharp_path_prefixes=read_rules(
             csharp_section.get("path_prefixes", []), "csharp.path_prefixes"
         ),
+        go_crate_seeds=read_names(go_section.get("crate_seeds", []), "go.crate_seeds"),
+        go_path_prefixes=read_rules(
+            go_section.get("path_prefixes", []), "go.path_prefixes"
+        ),
         cqs_crate_seeds=read_names(
             cqs_section.get("crate_seeds", []),
             "constructed_quest_prototype.crate_seeds",
@@ -420,6 +431,7 @@ def load_scope_config(config_path: Path | None = None) -> ScopeConfig:
         tv_steps=read_names(payload.get("tv_steps", []), "tv_steps"),
         python_steps=read_names(payload.get("python_steps", []), "python_steps"),
         csharp_steps=read_names(payload.get("csharp_steps", []), "csharp_steps"),
+        go_steps=read_names(payload.get("go_steps", []), "go_steps"),
         cqs_steps=read_names(payload.get("cqs_steps", []), "cqs_steps"),
     )
 
@@ -546,6 +558,13 @@ def scoped_domains(config: ScopeConfig) -> tuple[ScopedDomain, ...]:
             path_prefixes=config.csharp_path_prefixes,
             file_extensions=(),
             gated_steps=config.csharp_steps,
+        ),
+        ScopedDomain(
+            name="go",
+            crate_seeds=config.go_crate_seeds,
+            path_prefixes=config.go_path_prefixes,
+            file_extensions=GO_EXTENSIONS,
+            gated_steps=config.go_steps,
         ),
         ScopedDomain(
             name="cqs",

--- a/scripts/review/review_scope_config.json
+++ b/scripts/review/review_scope_config.json
@@ -46,6 +46,12 @@
       "client/Assets/"
     ]
   },
+  "go": {
+    "crate_seeds": [],
+    "path_prefixes": [
+      "prototypes/"
+    ]
+  },
   "constructed_quest_prototype": {
     "crate_seeds": [],
     "path_prefixes": [
@@ -75,6 +81,10 @@
     "test-core",
     "python-test",
     "pyre-check",
+    "go-prototypes-check-format",
+    "go-prototypes-typecheck",
+    "go-prototypes-lint",
+    "go-prototypes-test",
     "parser-test",
     "tv-check",
     "tv-clippy",
@@ -85,7 +95,11 @@
     "build",
     "clippy",
     "test-core",
-    "local-unity-test"
+    "local-unity-test",
+    "go-prototypes-check-format",
+    "go-prototypes-typecheck",
+    "go-prototypes-lint",
+    "go-prototypes-test"
   ],
   "parser_steps": [
     "parser-test"
@@ -101,6 +115,12 @@
   ],
   "csharp_steps": [
     "local-unity-test"
+  ],
+  "go_steps": [
+    "go-prototypes-check-format",
+    "go-prototypes-typecheck",
+    "go-prototypes-lint",
+    "go-prototypes-test"
   ],
   "cqs_steps": [
     "cqs-check"

--- a/scripts/review/tests/test_review_scripts.py
+++ b/scripts/review/tests/test_review_scripts.py
@@ -197,6 +197,10 @@ class ReviewScopePlannerTests(unittest.TestCase):
             "tv-check",
             "tv-clippy",
             "tv-test",
+            "go-prototypes-check-format",
+            "go-prototypes-typecheck",
+            "go-prototypes-lint",
+            "go-prototypes-test",
         ]
         self.config = review_scope.ScopeConfig(
             required_global_full_triggers=(
@@ -225,6 +229,8 @@ class ReviewScopePlannerTests(unittest.TestCase):
             tv_path_prefixes=("rules_engine/src/tv/", "rules_engine/tests/tv_tests/"),
             csharp_crate_seeds=(),
             csharp_path_prefixes=("client/Assets/",),
+            go_crate_seeds=(),
+            go_path_prefixes=("prototypes/",),
             cqs_crate_seeds=(),
             cqs_path_prefixes=("scripts/constructed_quest_prototype/",),
             always_run_steps=(
@@ -245,6 +251,10 @@ class ReviewScopePlannerTests(unittest.TestCase):
                 "rlf-lint",
                 "test-core",
                 "python-test",
+                "go-prototypes-check-format",
+                "go-prototypes-typecheck",
+                "go-prototypes-lint",
+                "go-prototypes-test",
                 "parser-test",
                 "tv-check",
                 "tv-clippy",
@@ -256,11 +266,21 @@ class ReviewScopePlannerTests(unittest.TestCase):
                 "clippy",
                 "test-core",
                 "local-unity-test",
+                "go-prototypes-check-format",
+                "go-prototypes-typecheck",
+                "go-prototypes-lint",
+                "go-prototypes-test",
             ),
             parser_steps=("parser-test",),
             tv_steps=("tv-check", "tv-clippy", "tv-test"),
             python_steps=("python-test",),
             csharp_steps=("local-unity-test",),
+            go_steps=(
+                "go-prototypes-check-format",
+                "go-prototypes-typecheck",
+                "go-prototypes-lint",
+                "go-prototypes-test",
+            ),
             cqs_steps=("cqs-check",),
             core_path_prefixes=(
                 "client/Assets/StreamingAssets/",
@@ -631,6 +651,25 @@ class ReviewScopePlannerTests(unittest.TestCase):
         )
         self.assertNotIn("python-test", decision.skipped_steps)
 
+    def test_go_change_selects_go_prototype_steps(self) -> None:
+        env = {
+            "REVIEW_SCOPE_MODE": "enforce",
+            "REVIEW_SCOPE_CHANGED_FILES": "prototypes/hello_world/main.go",
+        }
+        decision = review_scope.plan_review_scope(
+            self.step_names,
+            env=env,
+            repo_root=Path.cwd(),
+            config=self.config,
+            metadata=self.metadata,
+        )
+        self.assertFalse(decision.forced_full)
+        self.assertIn("go", decision.domains)
+        self.assertIn("go-prototypes-check-format", decision.selected_steps)
+        self.assertIn("go-prototypes-typecheck", decision.selected_steps)
+        self.assertIn("go-prototypes-lint", decision.selected_steps)
+        self.assertIn("go-prototypes-test", decision.selected_steps)
+
     def test_shell_script_change_is_core_not_unmapped(self) -> None:
         env = {
             "REVIEW_SCOPE_MODE": "enforce",
@@ -650,7 +689,9 @@ class ReviewScopePlannerTests(unittest.TestCase):
         self.assertIn("clippy", decision.selected_steps)
         self.assertIn("test-core", decision.selected_steps)
         self.assertNotIn("python-test", decision.selected_steps)
+        self.assertNotIn("go-prototypes-test", decision.selected_steps)
         self.assertIn("python-test", decision.skipped_steps)
+        self.assertIn("go-prototypes-test", decision.skipped_steps)
 
     def test_quest_prototype_change_is_core_not_unmapped(self) -> None:
         env = {


### PR DESCRIPTION
### Motivation

- Introduce a place for standalone Go prototypes and ensure they are covered by the repository's review, formatting, typecheck, lint and test pipelines.
- Make scoped review tooling aware of changes under `prototypes/` so only relevant steps run for Go prototype edits.

### Description

- Add a `prototypes/` layout with `go.work`, a `hello_world` module, `main.go`, a unit test, and a `README.md` describing usage.
- Add Go-related `just` targets for formatting (`fmt-go-prototypes`), format checks, typechecking (`go build`), linting (`go vet`) and tests, and wire them into `review-direct`, `review-verbose`, and `fmt` targets in `justfile`.
- Extend review planner code (`scripts/review/review_scope.py`) to recognize Go file extensions and new `go` section in the scope config and add a `go` scoped domain with gated steps, and add corresponding runner steps in `scripts/review/review_runner.py`.
- Update `scripts/review/review_scope_config.json` and unit tests (`scripts/review/tests/test_review_scripts.py`) to include and validate the new Go prototype steps and behavior.

### Testing

- Ran the review scope planner unit tests with `python -m unittest scripts.review.tests.test_review_scripts` and the updated tests passed.
- Exercised the new `go` prototype sample with `go test` via the added `go-prototypes-test` step in CI review flow during local verification and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97ec899bc832f9f0e2b06ecacfefa)